### PR TITLE
Add line and column numbers to `ParseError`

### DIFF
--- a/src/Text/Parsing/Parser.purs
+++ b/src/Text/Parsing/Parser.purs
@@ -19,23 +19,32 @@ import Control.Monad.Error.Trans
 import Control.MonadPlus
 import Control.Plus
 
+import Text.Parsing.Parser.Pos
+
 data ParseError = ParseError
   { message :: String
+  , position :: Position
   }
 
 instance errorParseError :: Error ParseError where
-  noMsg = ParseError { message: "" }
-  strMsg msg = ParseError { message: msg }
+  noMsg = ParseError { message: "", position: initialPos }
+  strMsg msg = ParseError { message: msg, position: initialPos }
 
 instance showParseError :: Show ParseError where
-  show (ParseError msg) = "ParseError { message: " ++ msg.message ++ " }"
+  show (ParseError msg) = "ParseError { message: " ++ msg.message ++ ", position: " ++ show msg.position ++ " }"
 
-newtype ParserT s m a = ParserT (s -> m { input :: s, result :: Either ParseError a, consumed :: Boolean })
+-- | `PState` contains the remaining input and current position.
+data PState s = PState
+  { input :: s
+  , position :: Position
+  }
 
-unParserT :: forall m s a. ParserT s m a -> s -> m { input :: s, result :: Either ParseError a, consumed :: Boolean }
+newtype ParserT s m a = ParserT (PState s -> m { input :: s, result :: Either ParseError a, consumed :: Boolean, position :: Position })
+
+unParserT :: forall m s a. ParserT s m a -> PState s -> m { input :: s, result :: Either ParseError a, consumed :: Boolean, position :: Position }
 unParserT (ParserT p) = p
 
-runParserT :: forall m s a. (Monad m) => s -> ParserT s m a -> m (Either ParseError a)
+runParserT :: forall m s a. (Monad m) => PState s -> ParserT s m a -> m (Either ParseError a)
 runParserT s p = do
   o <- unParserT p s
   return o.result
@@ -43,18 +52,18 @@ runParserT s p = do
 type Parser s a = ParserT s Identity a
 
 runParser :: forall s a. s -> Parser s a -> Either ParseError a
-runParser s = runIdentity <<< runParserT s
+runParser s = runIdentity <<< runParserT (PState { input: s, position: initialPos })
 
 instance functorParserT :: (Functor m) => Functor (ParserT s m) where
   (<$>) f p = ParserT $ \s -> f' <$> unParserT p s
     where
-    f' o = { input: o.input, result: f <$> o.result, consumed: o.consumed }
+    f' o = { input: o.input, result: f <$> o.result, consumed: o.consumed, position: o.position }
 
 instance applyParserT :: (Monad m) => Apply (ParserT s m) where
   (<*>) = ap
 
 instance applicativeParserT :: (Monad m) => Applicative (ParserT s m) where
-  pure a = ParserT $ \s -> pure { input: s, result: Right a, consumed: false }
+  pure a = ParserT $ \(PState { input: s, position: pos }) -> pure { input: s, result: Right a, consumed: false, position: pos }
 
 instance altParserT :: (Monad m) => Alt (ParserT s m) where
   (<|>) p1 p2 = ParserT $ \s -> unParserT p1 s >>= \o ->
@@ -70,29 +79,35 @@ instance alternativeParserT :: (Monad m) => Alternative (ParserT s m)
 instance bindParserT :: (Monad m) => Bind (ParserT s m) where
   (>>=) p f = ParserT $ \s -> unParserT p s >>= \o ->
     case o.result of
-      Left err -> return { input: o.input, result: Left err, consumed: o.consumed }
-      Right a -> updateConsumedFlag o.consumed <$> unParserT (f a) o.input
+      Left err -> return { input: o.input, result: Left err, consumed: o.consumed, position: o.position }
+      Right a -> updateConsumedFlag o.consumed <$> unParserT (f a) (PState { input: o.input, position: o.position })
     where
-    updateConsumedFlag c o = { input: o.input, consumed: c || o.consumed, result: o.result }
+    updateConsumedFlag c o = { input: o.input, consumed: c || o.consumed, result: o.result, position: o.position }
 
 instance monadParserT :: (Monad m) => Monad (ParserT s m)
 
 instance monadPlusParserT :: (Monad m) => MonadPlus (ParserT s m)
 
 instance monadTransParserT :: MonadTrans (ParserT s) where
-  lift m = ParserT $ \s -> (\a -> { input: s, consumed: false, result: Right a }) <$> m
+  lift m = ParserT $ \(PState { input: s, position: pos }) -> (\a -> { input: s, consumed: false, result: Right a, position: pos }) <$> m
 
 instance monadStateParserT :: (Monad m) => MonadState s (ParserT s m) where
-  state f = ParserT $ \s ->
+  state f = ParserT $ \(PState { input: s, position: pos }) ->
     return $ case f s of
-      Tuple a s' -> { input: s', consumed: false, result: Right a }
+      Tuple a s' -> { input: s', consumed: false, result: Right a, position: pos }
 
 instance lazy1ParserT :: Lazy1 (ParserT s m) where
   defer1 f = ParserT $ \s -> unParserT (f unit) s
 
 consume :: forall s m. (Monad m) => ParserT s m Unit
-consume = ParserT $ \s -> return { consumed: true, input: s, result: Right unit }
+consume = ParserT $ \(PState { input: s, position: pos }) -> return { consumed: true, input: s, result: Right unit, position: pos }
 
 fail :: forall m s a. (Monad m) => String -> ParserT s m a
-fail message = ParserT $ \s -> return { input: s, consumed: false, result: Left (ParseError { message: message }) }
+fail message = ParserT $ \(PState { input: s, position: pos }) -> return $ parseFailed s pos message
+
+-- | Creates a failed parser state for the remaining input `s` and current position
+-- | with an error message.
+-- | Most of the time, `fail` should be used instead.
+parseFailed :: forall s a. s -> Position -> String -> { input :: s, result :: Either ParseError a, consumed :: Boolean, position :: Position }
+parseFailed s pos message = { input: s, consumed: false, result: Left (ParseError { message: message, position: pos }), position: pos }
 

--- a/src/Text/Parsing/Parser/Pos.purs
+++ b/src/Text/Parsing/Parser/Pos.purs
@@ -1,0 +1,35 @@
+module Text.Parsing.Parser.Pos where
+
+import Data.String (split)
+import Data.Foldable (foldl)
+
+-- | `Position` represents the position of the parser in the input.
+-- | - `line` is the current line in the input
+-- | - `column` is the column of the next character in the current line that will be parsed
+data Position = Position
+  { line :: Number
+  , column :: Number
+  }
+
+instance showPosition :: Show Position where
+  show (Position { line: line, column: column }) =
+    "Position { line: " ++ show line ++ ", column: " ++ show column ++ " }"
+
+instance eqPosition :: Eq Position where
+  (==) (Position { line: l1, column: c1 }) (Position { line: l2, column: c2 }) =
+    l1 == l2 && c1 == c2
+  (/=) p1 p2 = not (p1 == p2)
+
+-- | The `Position` before any input has been parsed.
+initialPos :: Position
+initialPos = Position { line: 1, column: 1 }
+
+-- | Updates a `Position` by adding the columns and lines in `String`.
+updatePosString :: Position -> String -> Position
+updatePosString pos str = foldl updatePosChar pos (split "" str)
+  where
+  updatePosChar (Position pos) c = case c of
+    "\n" -> Position { line: pos.line + 1, column: 1 }
+    "\r" -> Position { line: pos.line + 1, column: 1 }
+    "\t" -> Position { line: pos.line,     column: pos.column + 8 - (pos.column - 1) % 8 }
+    _    -> Position { line: pos.line,     column: pos.column + 1 }


### PR DESCRIPTION
This fork adds line and column numbers to parsers and error messages.

It was necessary to change the types of `runParserT` and `unParserT`, see 42375404e09fef1b3333acd24854d90afdf500d7. The `runParser` function remains unchanged.

Related to #15.

Feel free to ask questions and criticize.