### PR TITLE
Add failing newlines test

### DIFF
--- a/test/Main.purs
+++ b/test/Main.purs
@@ -90,6 +90,9 @@ isA A = true
 isA _ = false
 
 main = do
+
+  parseTest "\n" Nil $ many $ char '\n' *> char '\n'
+
   parseTest "(((a)))" 3 nested
   parseTest "aaa" (Cons "a" (Cons "a" (Cons "a" Nil))) $ many (string "a")
   parseTest "(ab)" (Just "b") $ parens do

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -39,11 +39,15 @@ nested = fix \p -> (do
 parseTest :: forall s a eff. (Show a, Eq a) => s -> a -> Parser s a -> Eff (console :: CONSOLE, assert :: ASSERT | eff) Unit
 parseTest input expected p = case runParser input p of
   Right actual -> assert (expected == actual)
-  Left err -> print ("error: " ++ show err)
+  Left err -> do
+    print $ "error: " ++ show err
+    assert false
 
 parseErrorTestPosition :: forall s a eff. (Show a) => Parser s a -> s -> Position -> Eff (console :: CONSOLE, assert :: ASSERT | eff) Unit
 parseErrorTestPosition p input expected = case runParser input p of
-  Right _ -> print "error: ParseError expected!"
+  Right _ -> do
+    print "error: ParseError expected!"
+    assert false
   Left (ParseError { position: pos }) -> assert (expected == pos)
 
 opTest :: Parser String String
@@ -91,6 +95,13 @@ isA _ = false
 
 main = do
 
+  parseTest "" Nil $ many $ char '\n' *> char '\n'
+  parseTest "" Nil $ many $ string "\n\n"
+
+  parseTest "\n" (Cons '\n' Nil) $ many $ char '\n'
+  parseTest "\n" (Cons "\n" Nil) $ many $ string "\n"
+
+  parseTest "\n" Nil $ many $ string "\n\n"
   parseTest "\n" Nil $ many $ char '\n' *> char '\n'
 
   parseTest "(((a)))" 3 nested


### PR DESCRIPTION
Add a failing test and some extra that pass, so that we can analyse and fix this.

In summary:

```purescript

--| Given the input "foo\nbar"

--| This will work:
xs <- many $ do
  char 'x'
  char 'x'
 
--| But this will NOT:
xs <- many $ do
  char '\n'
  char '\n'
```

Please note that the input string *needs*  at least one `\n` for the it to fail.

Note, I also call `assert false` in order to exit with non-0. Usually, `assert` should take a string, but the purescript version does not, so I `print` and then call `assert false`. Either way, it's irrelevant to this PR in the end.