### PR TITLE
Fix warnings

### DIFF
--- a/docs/Text/Parsing/Parser.md
+++ b/docs/Text/Parsing/Parser.md
@@ -11,8 +11,7 @@ A parsing error, consisting of a message and position information.
 
 ##### Instances
 ``` purescript
-instance errorParseError :: Error ParseError
-instance showParseError :: Show ParseError
+Show ParseError
 ```
 
 #### `PState`
@@ -37,18 +36,18 @@ The first type argument is the stream type. Typically, this is either `String`, 
 
 ##### Instances
 ``` purescript
-instance functorParserT :: (Functor m) => Functor (ParserT s m)
-instance applyParserT :: (Monad m) => Apply (ParserT s m)
-instance applicativeParserT :: (Monad m) => Applicative (ParserT s m)
-instance altParserT :: (Monad m) => Alt (ParserT s m)
-instance plusParserT :: (Monad m) => Plus (ParserT s m)
-instance alternativeParserT :: (Monad m) => Alternative (ParserT s m)
-instance bindParserT :: (Monad m) => Bind (ParserT s m)
-instance monadParserT :: (Monad m) => Monad (ParserT s m)
-instance monadPlusParserT :: (Monad m) => MonadPlus (ParserT s m)
-instance monadTransParserT :: MonadTrans (ParserT s)
-instance monadStateParserT :: (Monad m) => MonadState s (ParserT s m)
-instance lazyParserT :: Lazy (ParserT s m a)
+(Functor m) => Functor (ParserT s m)
+(Monad m) => Apply (ParserT s m)
+(Monad m) => Applicative (ParserT s m)
+(Monad m) => Alt (ParserT s m)
+(Monad m) => Plus (ParserT s m)
+(Monad m) => Alternative (ParserT s m)
+(Monad m) => Bind (ParserT s m)
+(Monad m) => Monad (ParserT s m)
+(Monad m) => MonadPlus (ParserT s m)
+MonadTrans (ParserT s)
+(Monad m) => MonadState s (ParserT s m)
+Lazy (ParserT s m a)
 ```
 
 #### `unParserT`

--- a/docs/Text/Parsing/Parser/Pos.md
+++ b/docs/Text/Parsing/Parser/Pos.md
@@ -14,8 +14,8 @@ data Position
 
 ##### Instances
 ``` purescript
-instance showPosition :: Show Position
-instance eqPosition :: Eq Position
+Show Position
+Eq Position
 ```
 
 #### `initialPos`

--- a/docs/Text/Parsing/Parser/String.md
+++ b/docs/Text/Parsing/Parser/String.md
@@ -61,7 +61,7 @@ Skip whitespace characters.
 #### `oneOf`
 
 ``` purescript
-oneOf :: forall s m a. (Monad m) => Array Char -> ParserT String m Char
+oneOf :: forall m. (Monad m) => Array Char -> ParserT String m Char
 ```
 
 Match one of the characters in the array.
@@ -69,7 +69,7 @@ Match one of the characters in the array.
 #### `noneOf`
 
 ``` purescript
-noneOf :: forall s m a. (Monad m) => Array Char -> ParserT String m Char
+noneOf :: forall m. (Monad m) => Array Char -> ParserT String m Char
 ```
 
 Match any character not in the array.

--- a/src/Text/Parsing/Parser.purs
+++ b/src/Text/Parsing/Parser.purs
@@ -4,19 +4,13 @@ import Prelude
 
 import Data.Either
 import Data.Identity
-import Data.Maybe
-import Data.Monoid
 import Data.Tuple
 
 import Control.Alt
 import Control.Alternative
 import Control.Lazy
-import Control.Monad
-import Control.Monad.Trans
-import Control.Monad.State.Class
-import Control.Monad.State.Trans
-import Control.Monad.Error.Class
-import Control.Monad.Except.Trans
+import Control.Monad.State.Class (MonadState)
+import Control.Monad.Trans (MonadTrans)
 import Control.MonadPlus
 import Control.Plus
 

--- a/src/Text/Parsing/Parser/Combinators.purs
+++ b/src/Text/Parsing/Parser/Combinators.purs
@@ -24,20 +24,13 @@ module Text.Parsing.Parser.Combinators where
 import Prelude
 
 import Data.Maybe
-import Data.Tuple
 import Data.Either
 import Data.List (List(..), (:), many, some, singleton)
 import Data.Foldable (Foldable, foldl)
 
 import Control.Alt
 import Control.Plus
-import Control.Alternative
 import Control.Apply
-import Control.Lazy
-import Control.Monad
-import Control.Monad.Error.Class
-import Control.Monad.State.Trans
-import Control.Monad.State.Class
 
 import Text.Parsing.Parser
 

--- a/src/Text/Parsing/Parser/Expr.purs
+++ b/src/Text/Parsing/Parser/Expr.purs
@@ -1,4 +1,4 @@
-module Text.Parsing.Parser.Expr 
+module Text.Parsing.Parser.Expr
   ( Assoc(..)
   , Operator(..)
   , OperatorTable()
@@ -7,7 +7,6 @@ module Text.Parsing.Parser.Expr
 
 import Prelude
 
-import Data.Either
 import Data.Foldable
 import Data.List (List(..), (:))
 
@@ -33,7 +32,7 @@ type SplitAccum m s a = { rassoc  :: List (ParserT s m (a -> a -> a))
 -- | Build a parser from an `OperatorTable`.
 -- |
 -- | For example:
--- | 
+-- |
 -- | ```purescript
 -- | buildExprParser [ [ Infix (string "/" $> div) AssocRight ]
 -- |                 , [ Infix (string "*" $> mul) AssocRight ]
@@ -43,70 +42,68 @@ type SplitAccum m s a = { rassoc  :: List (ParserT s m (a -> a -> a))
 -- | ```
 buildExprParser :: forall m s a. (Monad m) => OperatorTable m s a -> ParserT s m a -> ParserT s m a
 buildExprParser operators simpleExpr = foldl makeParser simpleExpr operators
-  
+
+makeParser :: forall m s a. (Monad m) => ParserT s m a -> Array (Operator m s a) -> ParserT s m a
+makeParser term ops = do
+  x <- termP prefixP term postfixP
+  rassocP x rassocOp prefixP term postfixP
+    <|> lassocP x lassocOp prefixP term postfixP
+    <|> nassocP x nassocOp prefixP term postfixP
+    <|> return x
+    <?> "operator"
   where
-      
-  makeParser :: ParserT s m a -> Array (Operator m s a) -> ParserT s m a 
-  makeParser term ops = do
-    x <- termP prefixP term postfixP
-    rassocP x rassocOp prefixP term postfixP
-      <|> lassocP x lassocOp prefixP term postfixP
-      <|> nassocP x nassocOp prefixP term postfixP
-      <|> return x
-      <?> "operator"
-    where
-    accum = foldr splitOp { rassoc:  Nil
-                          , lassoc:  Nil
-                          , nassoc:  Nil
-                          , prefix:  Nil
-                          , postfix: Nil
-                          } ops
-    
-    rassocOp  = choice accum.rassoc
-    lassocOp  = choice accum.lassoc
-    nassocOp  = choice accum.nassoc
-    prefixOp  = choice accum.prefix <?> ""
-    postfixOp = choice accum.postfix <?> ""
-    
-    postfixP = postfixOp <|> return id
-    prefixP = prefixOp <|> return id
-    
-  splitOp :: forall m s a. Operator m s a -> SplitAccum m s a -> SplitAccum m s a
-  splitOp (Infix op AssocNone)  accum = accum { nassoc  = op : accum.nassoc }
-  splitOp (Infix op AssocLeft)  accum = accum { lassoc  = op : accum.lassoc }
-  splitOp (Infix op AssocRight) accum = accum { rassoc  = op : accum.rassoc }
-  splitOp (Prefix  op)          accum = accum { prefix  = op : accum.prefix }
-  splitOp (Postfix op)          accum = accum { postfix = op : accum.postfix }
+  accum = foldr splitOp { rassoc:  Nil
+                        , lassoc:  Nil
+                        , nassoc:  Nil
+                        , prefix:  Nil
+                        , postfix: Nil
+                        } ops
 
-  rassocP :: forall m a b c s. (Monad m) => a -> ParserT s m (a -> a -> a) -> ParserT s m (b -> c) -> ParserT s m b -> ParserT s m (c -> a) -> ParserT s m a
-  rassocP x rassocOp prefixP term postfixP = do
-    f <- rassocOp
-    y <- do
-      z <- termP prefixP term postfixP
-      rassocP1 z rassocOp prefixP term postfixP
-    return (f x y)
+  rassocOp  = choice accum.rassoc
+  lassocOp  = choice accum.lassoc
+  nassocOp  = choice accum.nassoc
+  prefixOp  = choice accum.prefix <?> ""
+  postfixOp = choice accum.postfix <?> ""
 
-  rassocP1 :: forall m a b c s. (Monad m) => a -> ParserT s m (a -> a -> a) -> ParserT s m (b -> c) -> ParserT s m b -> ParserT s m (c -> a) -> ParserT s m a
-  rassocP1 x rassocOp prefixP term postfixP = rassocP x rassocOp prefixP term postfixP <|> return x
+  postfixP = postfixOp <|> return id
+  prefixP = prefixOp <|> return id
 
-  lassocP :: forall m a b c s. (Monad m) => a -> ParserT s m (a -> a -> a) -> ParserT s m (b -> c) -> ParserT s m b -> ParserT s m (c -> a) -> ParserT s m a
-  lassocP x lassocOp prefixP term postfixP = do
-    f <- lassocOp
-    y <- termP prefixP term postfixP
-    lassocP1 (f x y) lassocOp prefixP term postfixP
+splitOp :: forall m s a. Operator m s a -> SplitAccum m s a -> SplitAccum m s a
+splitOp (Infix op AssocNone)  accum = accum { nassoc  = op : accum.nassoc }
+splitOp (Infix op AssocLeft)  accum = accum { lassoc  = op : accum.lassoc }
+splitOp (Infix op AssocRight) accum = accum { rassoc  = op : accum.rassoc }
+splitOp (Prefix  op)          accum = accum { prefix  = op : accum.prefix }
+splitOp (Postfix op)          accum = accum { postfix = op : accum.postfix }
 
-  lassocP1 :: forall m a b c s. (Monad m) => a -> ParserT s m (a -> a -> a) -> ParserT s m (b -> c) -> ParserT s m b -> ParserT s m (c -> a) -> ParserT s m a
-  lassocP1 x lassocOp prefixP term postfixP = lassocP x lassocOp prefixP term postfixP <|> return x
+rassocP :: forall m a b c s. (Monad m) => a -> ParserT s m (a -> a -> a) -> ParserT s m (b -> c) -> ParserT s m b -> ParserT s m (c -> a) -> ParserT s m a
+rassocP x rassocOp prefixP term postfixP = do
+  f <- rassocOp
+  y <- do
+    z <- termP prefixP term postfixP
+    rassocP1 z rassocOp prefixP term postfixP
+  return (f x y)
 
-  nassocP :: forall m a b c d e s. (Monad m) => a -> ParserT s m (a -> d -> e) -> ParserT s m (b -> c) -> ParserT s m b -> ParserT s m (c -> d) -> ParserT s m e
-  nassocP x nassocOp prefixP term postfixP = do
-    f <- nassocOp
-    y <- termP prefixP term postfixP
-    return (f x y)
+rassocP1 :: forall m a b c s. (Monad m) => a -> ParserT s m (a -> a -> a) -> ParserT s m (b -> c) -> ParserT s m b -> ParserT s m (c -> a) -> ParserT s m a
+rassocP1 x rassocOp prefixP term postfixP = rassocP x rassocOp prefixP term postfixP <|> return x
 
-  termP :: forall m s a b c. (Monad m) => ParserT s m (a -> b) -> ParserT s m a -> ParserT s m (b -> c) -> ParserT s m c
-  termP prefixP term postfixP = do
-    pre   <- prefixP
-    x     <- term
-    post  <- postfixP
-    return (post (pre x))
+lassocP :: forall m a b c s. (Monad m) => a -> ParserT s m (a -> a -> a) -> ParserT s m (b -> c) -> ParserT s m b -> ParserT s m (c -> a) -> ParserT s m a
+lassocP x lassocOp prefixP term postfixP = do
+  f <- lassocOp
+  y <- termP prefixP term postfixP
+  lassocP1 (f x y) lassocOp prefixP term postfixP
+
+lassocP1 :: forall m a b c s. (Monad m) => a -> ParserT s m (a -> a -> a) -> ParserT s m (b -> c) -> ParserT s m b -> ParserT s m (c -> a) -> ParserT s m a
+lassocP1 x lassocOp prefixP term postfixP = lassocP x lassocOp prefixP term postfixP <|> return x
+
+nassocP :: forall m a b c d e s. (Monad m) => a -> ParserT s m (a -> d -> e) -> ParserT s m (b -> c) -> ParserT s m b -> ParserT s m (c -> d) -> ParserT s m e
+nassocP x nassocOp prefixP term postfixP = do
+  f <- nassocOp
+  y <- termP prefixP term postfixP
+  return (f x y)
+
+termP :: forall m s a b c. (Monad m) => ParserT s m (a -> b) -> ParserT s m a -> ParserT s m (b -> c) -> ParserT s m c
+termP prefixP term postfixP = do
+  pre   <- prefixP
+  x     <- term
+  post  <- postfixP
+  return (post (pre x))

--- a/src/Text/Parsing/Parser/String.purs
+++ b/src/Text/Parsing/Parser/String.purs
@@ -7,16 +7,9 @@ import Prelude
 import Data.String
 import Data.Either
 import Data.Foldable
-import Data.Monoid
 import Data.Maybe
 import Data.Char (toString)
 import Data.Array (many)
-import Data.List (List(..), (:), fromList)
-
-import Control.Alt
-import Control.Alternative
-import Control.Monad.Error.Class
-import Control.Monad.State.Class
 
 import Text.Parsing.Parser
 import Text.Parsing.Parser.Combinators

--- a/src/Text/Parsing/Parser/Token.purs
+++ b/src/Text/Parsing/Parser/Token.purs
@@ -4,16 +4,13 @@ module Text.Parsing.Parser.Token where
 
 import Prelude
 
-import Data.String
 import Data.Either
-import Data.List (List(..), (:), many, some)
+import Data.List (List(..))
 
 import Control.Monad.State.Class hiding (get)
-import Control.Monad.Error.Class
 import Control.MonadPlus
 
 import Text.Parsing.Parser
-import Text.Parsing.Parser.String
 import Text.Parsing.Parser.Combinators
 import Text.Parsing.Parser.Pos
 


### PR DESCRIPTION
This doesn't fix absolutely every warning; there are still two redundant
import warnings in Text.Parsing.Parser, arising from the imports of
Control.Monad.State.Class and Control.Monad.Trans.

Unfortunately, the compiler (0.7.6.1) is wrong; they are not redundant.
This is now fixed in the compiler, though, so these warnings should just
disappear after upgrading.