### PR TITLE
Add Text.Parsing.Parser.Language and Token modules.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -18,3 +18,31 @@ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+-------------------------------------------------------------------------------
+
+The `Text.Parsing.Parser.Token` and `Text.Parsing.Parser.Language` modules have
+large amounts of code adopted from the Haskell library parsec.  parsec's
+license is reproduced below:
+
+Copyright 1999-2000, Daan Leijen; 2007, Paolo Martini. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice,
+  this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+This software is provided by the copyright holders "as is" and any express or
+implied warranties, including, but not limited to, the implied warranties of
+merchantability and fitness for a particular purpose are disclaimed. In no
+event shall the copyright holders be liable for any direct, indirect,
+incidental, special, exemplary, or consequential damages (including, but not
+limited to, procurement of substitute goods or services; loss of use, data,
+or profits; or business interruption) however caused and on any theory of
+liability, whether in contract, strict liability, or tort (including
+negligence or otherwise) arising in any way out of the use of this software,
+even if advised of the possibility of such damage.

--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,9 @@
     "purescript-lists": "^0.7.0",
     "purescript-maybe": "^0.3.0",
     "purescript-strings": "~0.7.0",
-    "purescript-transformers": "^0.8.1"
+    "purescript-transformers": "^0.8.1",
+    "purescript-unicode": "git://github.com/purescript-contrib/purescript-unicode#unicode",
+    "purescript-integers": "^0.2.0"
   },
   "devDependencies": {
     "purescript-console": "^0.1.0",

--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,7 @@
     "purescript-maybe": "^0.3.0",
     "purescript-strings": "~0.7.0",
     "purescript-transformers": "^0.8.1",
-    "purescript-unicode": "git://github.com/purescript-contrib/purescript-unicode#unicode",
+    "purescript-unicode": "^0.0.1",
     "purescript-integers": "^0.2.0"
   },
   "devDependencies": {

--- a/src/Text/Parsing/Parser/Combinators.purs
+++ b/src/Text/Parsing/Parser/Combinators.purs
@@ -38,6 +38,10 @@ import Text.Parsing.Parser
 (<?>) :: forall m s a. (Monad m) => ParserT s m a -> String -> ParserT s m a
 (<?>) p msg = p <|> fail ("Expected " ++ msg)
 
+-- | Flipped `(<?>)`.
+(<??>) :: forall m s a. (Monad m) => String -> ParserT s m a -> ParserT s m a
+(<??>) = flip (<?>)
+
 -- | Wrap a parser with opening and closing markers.
 -- |
 -- | For example:
@@ -196,4 +200,3 @@ many1Till p end = do
   x <- p
   xs <- manyTill p end
   return (x:xs)
-

--- a/src/Text/Parsing/Parser/Language.purs
+++ b/src/Text/Parsing/Parser/Language.purs
@@ -21,9 +21,8 @@ import Text.Parsing.Parser.Token
 -----------------------------------------------------------
 
 -- | This is a minimal token definition for Haskell style languages. It
--- defines the style of comments, valid identifiers and case
--- sensitivity. It does not define any reserved words or operators.
-
+-- | defines the style of comments, valid identifiers and case
+-- | sensitivity. It does not define any reserved words or operators.
 haskellStyle :: LanguageDef
 haskellStyle = LanguageDef (unGenLanguageDef emptyDef)
                 { commentStart    = "{-"
@@ -43,9 +42,8 @@ haskellStyle = LanguageDef (unGenLanguageDef emptyDef)
     op' = oneOf [':', '!', '#', '$', '%', '&', '*', '+', '.', '/', '<', '=', '>', '?', '@', '\\', '^', '|', '-', '~']
 
 -- | This is a minimal token definition for Java style languages. It
--- defines the style of comments, valid identifiers and case
--- sensitivity. It does not define any reserved words or operators.
-
+-- | defines the style of comments, valid identifiers and case
+-- | sensitivity. It does not define any reserved words or operators.
 javaStyle  :: LanguageDef
 javaStyle   = LanguageDef (unGenLanguageDef emptyDef)
                 { commentStart    = "/*"
@@ -64,10 +62,9 @@ javaStyle   = LanguageDef (unGenLanguageDef emptyDef)
 --------------------------------------------------------
 
 -- | This is the most minimal token definition. It is recommended to use
--- this definition as the basis for other definitions. `emptyDef` has
--- no reserved names or operators, is case sensitive and doesn't accept
--- comments, identifiers or operators.
-
+-- | this definition as the basis for other definitions. `emptyDef` has
+-- | no reserved names or operators, is case sensitive and doesn't accept
+-- | comments, identifiers or operators.
 emptyDef :: LanguageDef
 emptyDef = LanguageDef
             { commentStart:    ""
@@ -90,13 +87,11 @@ emptyDef = LanguageDef
 -- -- Haskell
 -- -----------------------------------------------------------
 
--- -- | A lexer for the haskell language.
-
+-- | A lexer for the haskell language.
 haskell :: TokenParser
 haskell = makeTokenParser haskellDef
 
--- -- | The language definition for the Haskell language.
-
+-- | The language definition for the Haskell language.
 haskellDef  :: LanguageDef
 haskellDef   =
     case haskell98Def of
@@ -109,8 +104,7 @@ haskellDef   =
                                    ]
                 }
 
--- -- | The language definition for the language Haskell98.
-
+-- | The language definition for the language Haskell98.
 haskell98Def :: LanguageDef
 haskell98Def = LanguageDef (unGenLanguageDef haskellStyle)
                 { reservedOpNames = ["::","..","=","\\","|","<-","->","@","~","=>"]

--- a/src/Text/Parsing/Parser/Language.purs
+++ b/src/Text/Parsing/Parser/Language.purs
@@ -1,11 +1,11 @@
 
 module Text.Parsing.Parser.Language
-    -- ( haskellDef, haskell
-    -- , mondrianDef, mondrian
-    -- , emptyDef
-    -- , haskellStyle
-    -- , javaStyle
-    -- )
+    ( haskellDef
+    , haskell
+    , emptyDef
+    , haskellStyle
+    , javaStyle
+    )
       where
 
 import Prelude

--- a/src/Text/Parsing/Parser/Language.purs
+++ b/src/Text/Parsing/Parser/Language.purs
@@ -1,0 +1,125 @@
+
+module Text.Parsing.Parser.Language
+    -- ( haskellDef, haskell
+    -- , mondrianDef, mondrian
+    -- , emptyDef
+    -- , haskellStyle
+    -- , javaStyle
+    -- )
+      where
+
+import Prelude
+
+import Control.Alt
+
+import Text.Parsing.Parser
+import Text.Parsing.Parser.String
+import Text.Parsing.Parser.Token
+
+-----------------------------------------------------------
+-- Styles: haskellStyle, javaStyle
+-----------------------------------------------------------
+
+-- | This is a minimal token definition for Haskell style languages. It
+-- defines the style of comments, valid identifiers and case
+-- sensitivity. It does not define any reserved words or operators.
+
+haskellStyle :: LanguageDef
+haskellStyle = LanguageDef (unGenLanguageDef emptyDef)
+                { commentStart    = "{-"
+                , commentEnd      = "-}"
+                , commentLine     = "--"
+                , nestedComments  = true
+                , identStart      = letter
+                , identLetter     = alphaNum <|> oneOf ['_', '\'']
+                , opStart         = op'
+                , opLetter        = op'
+                , reservedOpNames = []
+                , reservedNames   = []
+                , caseSensitive   = true
+                }
+  where
+    op' :: forall m . (Monad m) => ParserT String m Char
+    op' = oneOf [':', '!', '#', '$', '%', '&', '*', '+', '.', '/', '<', '=', '>', '?', '@', '\\', '^', '|', '-', '~']
+
+-- | This is a minimal token definition for Java style languages. It
+-- defines the style of comments, valid identifiers and case
+-- sensitivity. It does not define any reserved words or operators.
+
+javaStyle  :: LanguageDef
+javaStyle   = LanguageDef (unGenLanguageDef emptyDef)
+                { commentStart    = "/*"
+                , commentEnd      = "*/"
+                , commentLine     = "//"
+                , nestedComments  = true
+                , identStart      = letter
+                , identLetter     = alphaNum <|> oneOf ['_', '\'']
+                , reservedNames   = []
+                , reservedOpNames = []
+                , caseSensitive   = false
+                }
+
+-----------------------------------------------------------
+-- minimal language definition
+--------------------------------------------------------
+
+-- | This is the most minimal token definition. It is recommended to use
+-- this definition as the basis for other definitions. `emptyDef` has
+-- no reserved names or operators, is case sensitive and doesn't accept
+-- comments, identifiers or operators.
+
+emptyDef :: LanguageDef
+emptyDef = LanguageDef
+            { commentStart:    ""
+            , commentEnd:      ""
+            , commentLine:     ""
+            , nestedComments:  true
+            , identStart:      letter <|> char '_'
+            , identLetter:     alphaNum <|> oneOf ['_', '\'']
+            , opStart:         op'
+            , opLetter:        op'
+            , reservedOpNames: []
+            , reservedNames:   []
+            , caseSensitive:   true
+            }
+  where
+    op' :: forall m . (Monad m) => ParserT String m Char
+    op' = oneOf [':', '!', '#', '$', '%', '&', '*', '+', '.', '/', '<', '=', '>', '?', '@', '\\', '^', '|', '-', '~']
+
+-- -----------------------------------------------------------
+-- -- Haskell
+-- -----------------------------------------------------------
+
+-- -- | A lexer for the haskell language.
+
+haskell :: TokenParser
+haskell = makeTokenParser haskellDef
+
+-- -- | The language definition for the Haskell language.
+
+haskellDef  :: LanguageDef
+haskellDef   =
+    case haskell98Def of
+        (LanguageDef def) -> LanguageDef def
+                { identLetter    = def.identLetter <|> char '#'
+                , reservedNames  = def.reservedNames <>
+                                   ["foreign","import","export","primitive"
+                                   ,"_ccall_","_casm_"
+                                   ,"forall"
+                                   ]
+                }
+
+-- -- | The language definition for the language Haskell98.
+
+haskell98Def :: LanguageDef
+haskell98Def = LanguageDef (unGenLanguageDef haskellStyle)
+                { reservedOpNames = ["::","..","=","\\","|","<-","->","@","~","=>"]
+                , reservedNames   = [ "let","in","case","of","if","then","else"
+                                    , "data","type"
+                                    , "class","default","deriving","do","import"
+                                    , "infix","infixl","infixr","instance","module"
+                                    , "newtype","where"
+                                    , "primitive"
+                                    -- "as","qualified","hiding"
+                                    ]
+                }

--- a/src/Text/Parsing/Parser/Token.purs
+++ b/src/Text/Parsing/Parser/Token.purs
@@ -69,41 +69,41 @@ match tokpos tok = when tokpos (== tok)
 
 type LanguageDef = GenLanguageDef String Identity
 
--- | The @GenLanguageDef@ type is a record that contains all parameterizable
--- features of the "Text.Parsec.Token" module. The module "Text.Parsec.Language"
--- contains some default definitions.
+-- | The `GenLanguageDef` type is a record that contains all parameterizable
+-- | features of the "Text.Parsec.Token" module. The module `Text.Parsec.Languager`
+-- | contains some default definitions.
 newtype GenLanguageDef s m
     = LanguageDef {
     -- | Describes the start of a block comment. Use the empty string if the
-    -- language doesn't support block comments. For example \"\/*\".
+    -- | language doesn't support block comments. For example `/*`.
     commentStart   :: String,
     -- | Describes the end of a block comment. Use the empty string if the
-    -- language doesn't support block comments. For example \"*\/\".
+    -- | language doesn't support block comments. For example `*/`.
     commentEnd     :: String,
     -- | Describes the start of a line comment. Use the empty string if the
-    -- language doesn't support line comments. For example \"\/\/\".
+    -- | language doesn't support line comments. For example `//`.
     commentLine    :: String,
-    -- | Set to 'True' if the language supports nested block comments.
+    -- | Set to `true` if the language supports nested block comments.
     nestedComments :: Boolean,
     -- | This parser should accept any start characters of identifiers. For
-    -- example @letter \<|> char \'_\'@.
+    -- | example `letter <|> char '_'`.
     identStart     :: ParserT s m Char,
     -- | This parser should accept any legal tail characters of identifiers.
-    -- For example @alphaNum \<|> char \'_\'@.
+    -- | For example `alphaNum <|> char '_'`.
     identLetter    :: ParserT s m Char,
     -- | This parser should accept any start characters of operators. For
-    -- example @oneOf \":!#$%&*+.\/\<=>?\@\\\\^|-~\"@
+    -- | example `oneOf [':', '+', '=']`.
     opStart        :: ParserT s m Char,
     -- | This parser should accept any legal tail characters of operators.
-    -- Note that this parser should even be defined if the language doesn't
-    -- support user-defined operators, or otherwise the 'reservedOp'
-    -- parser won't work correctly.
+    -- | Note that this parser should even be defined if the language doesn't
+    -- | support user-defined operators, or otherwise the `reservedOp`
+    -- | parser won't work correctly.
     opLetter       :: ParserT s m Char,
     -- | The list of reserved identifiers.
     reservedNames  :: Array String,
     -- | The list of reserved operators.
     reservedOpNames:: Array String,
-    -- | Set to 'True' if the language is case sensitive.
+    -- | Set to `true` if the language is case sensitive.
     caseSensitive  :: Boolean
     }
 
@@ -128,142 +128,143 @@ unGenLanguageDef (LanguageDef langDef) = langDef
 type TokenParser = GenTokenParser String Identity
 
 -- | The type of the record that holds lexical parsers that work on
--- @s@ streams over a monad @m@.
-
+-- | `s` streams over a monad `m`.
 type GenTokenParser s m
     = {
         -- | This lexeme parser parses a legal identifier. Returns the identifier
-        -- string. This parser will fail on identifiers that are reserved
-        -- words. Legal identifier (start) characters and reserved words are
-        -- defined in the 'LanguageDef' that is passed to
-        -- 'makeTokenParser'. An @identifier@ is treated as
-        -- a single token using 'try'.
+        -- | string. This parser will fail on identifiers that are reserved
+        -- | words. Legal identifier (start) characters and reserved words are
+        -- | defined in the `LanguageDef` that is passed to
+        -- | `makeTokenParser`. An `identifier` is treated as
+        -- | a single token using `try`.
         identifier       :: ParserT s m String,
-        -- | The lexeme parser @reserved name@ parses @symbol
-        -- name@, but it also checks that the @name@ is not a prefix of a
-        -- valid identifier. A @reserved@ word is treated as a single token
-        -- using 'try'.
+        -- | The lexeme parser `reserved name` parses `symbol
+        -- | name`, but it also checks that the `name` is not a prefix of a
+        -- | valid identifier. A `reserved` word is treated as a single token
+        -- | using `try`.
         reserved         :: String -> ParserT s m Unit,
         -- | This lexeme parser parses a legal operator. Returns the name of the
-        -- operator. This parser will fail on any operators that are reserved
-        -- operators. Legal operator (start) characters and reserved operators
-        -- are defined in the 'LanguageDef' that is passed to
-        -- 'makeTokenParser'. An @operator@ is treated as a
-        -- single token using 'try'.
+        -- | operator. This parser will fail on any operators that are reserved
+        -- | operators. Legal operator (start) characters and reserved operators
+        -- | are defined in the `LanguageDef` that is passed to
+        -- | `makeTokenParser`. An `operator` is treated as a
+        -- | single token using `try`.
         operator         :: ParserT s m String,
-        -- |The lexeme parser @reservedOp name@ parses @symbol
-        -- name@, but it also checks that the @name@ is not a prefix of a
-        -- valid operator. A @reservedOp@ is treated as a single token using
-        -- 'try'.
+        -- |The lexeme parser `reservedOp name` parses `symbol
+        -- | name`, but it also checks that the `name` is not a prefix of a
+        -- | valid operator. A `reservedOp` is treated as a single token using
+        -- | `try`.
         reservedOp       :: String -> ParserT s m Unit,
         -- | This lexeme parser parses a single literal character. Returns the
-        -- literal character value. This parsers deals correctly with escape
-        -- sequences. The literal character is parsed according to the grammar
-        -- rules defined in the Haskell report (which matches most programming
-        -- languages quite closely).
+        -- | literal character value. This parsers deals correctly with escape
+        -- | sequences. The literal character is parsed according to the grammar
+        -- | rules defined in the Haskell report (which matches most programming
+        -- | languages quite closely).
         charLiteral      :: ParserT s m Char,
         -- | This lexeme parser parses a literal string. Returns the literal
-        -- string value. This parsers deals correctly with escape sequences and
-        -- gaps. The literal string is parsed according to the grammar rules
-        -- defined in the Haskell report (which matches most programming
-        -- languages quite closely).
+        -- | string value. This parsers deals correctly with escape sequences and
+        -- | gaps. The literal string is parsed according to the grammar rules
+        -- | defined in the Haskell report (which matches most programming
+        -- | languages quite closely).
         stringLiteral    :: ParserT s m String,
         -- | This lexeme parser parses a natural number (a positive whole
-        -- number). Returns the value of the number. The number can be
-        -- specified in 'decimal', 'hexadecimal' or
-        -- 'octal'. The number is parsed according to the grammar
-        -- rules in the Haskell report.
+        -- | number). Returns the value of the number. The number can be
+        -- | specified in `decimal`, `hexadecimal` or
+        -- | `octal`. The number is parsed according to the grammar
+        -- | rules in the Haskell report.
         natural          :: ParserT s m Int,
         -- | This lexeme parser parses an integer (a whole number). This parser
-        -- is like 'natural' except that it can be prefixed with
-        -- sign (i.e. \'-\' or \'+\'). Returns the value of the number. The
-        -- number can be specified in 'decimal', 'hexadecimal'
-        -- or 'octal'. The number is parsed according
-        -- to the grammar rules in the Haskell report.
+        -- | is like `natural` except that it can be prefixed with
+        -- | sign (i.e. `-` or `+`). Returns the value of the number. The
+        -- | number can be specified in `decimal`, `hexadecimal`
+        -- | or `octal`. The number is parsed according
+        -- | to the grammar rules in the Haskell report.
         integer          :: ParserT s m Int,
         -- | This lexeme parser parses a floating point value. Returns the value
-        -- of the number. The number is parsed according to the grammar rules
-        -- defined in the Haskell report.
+        -- | of the number. The number is parsed according to the grammar rules
+        -- | defined in the Haskell report.
         float            :: ParserT s m Number,
-        -- | This lexeme parser parses either 'natural' or a 'float'.
-        -- Returns the value of the number. This parsers deals with
-        -- any overlap in the grammar rules for naturals and floats. The number
-        -- is parsed according to the grammar rules defined in the Haskell report.
+        -- | This lexeme parser parses either `natural` or a `float`.
+        -- | Returns the value of the number. This parsers deals with
+        -- | any overlap in the grammar rules for naturals and floats. The number
+        -- | is parsed according to the grammar rules defined in the Haskell report.
         naturalOrFloat   :: ParserT s m (Either Int Number),
         -- | Parses a positive whole number in the decimal system. Returns the
-        -- value of the number.
+        -- | value of the number.
         decimal          :: ParserT s m Int,
         -- | Parses a positive whole number in the hexadecimal system. The number
-        -- should be prefixed with \"0x\" or \"0X\". Returns the value of the
-        -- number.
+        -- | should be prefixed with `0x` or `0X`. Returns the value of the
+        -- | number.
         hexadecimal      :: ParserT s m Int,
         -- | Parses a positive whole number in the octal system. The number
-        -- should be prefixed with \"0o\" or \"0O\". Returns the value of the
-        -- number.
+        -- | should be prefixed with `0o` or `0O`. Returns the value of the
+        -- | number.
         octal            :: ParserT s m Int,
-        -- | Lexeme parser @symbol s@ parses 'string' @s@ and skips
-        -- trailing white space.
+        -- | Lexeme parser `symbol s` parses `string` `s` and skips
+        -- | trailing white space.
         symbol           :: String -> ParserT s m String,
-        -- | @lexeme p@ first applies parser @p@ and than the 'whiteSpace'
-        -- parser, returning the value of @p@. Every lexical
-        -- token (lexeme) is defined using @lexeme@, this way every parse
-        -- starts at a point without white space. Parsers that use @lexeme@ are
-        -- called /lexeme/ parsers in this document.
-        --
-        -- The only point where the 'whiteSpace' parser should be
-        -- called explicitly is the start of the main parser in order to skip
-        -- any leading white space.
-        --
-        -- >    mainParser  = do{ whiteSpace
-        -- >                     ; ds <- many (lexeme digit)
-        -- >                     ; eof
-        -- >                     ; return (sum ds)
-        -- >                     }
+        -- | `lexeme p` first applies parser `p` and than the `whiteSpace`
+        -- | parser, returning the value of `p`. Every lexical
+        -- | token (lexeme) is defined using `lexeme`, this way every parse
+        -- | starts at a point without white space. Parsers that use `lexeme` are
+        -- | called *lexeme* parsers in this document.
+        -- |
+        -- | The only point where the `whiteSpace` parser should be
+        -- | called explicitly is the start of the main parser in order to skip
+        -- | any leading white space.
+        -- |
+        -- | ```purescript
+        -- | mainParser = do
+        -- |   whiteSpace
+        -- |   ds <- many (lexeme digit)
+        -- |   eof
+        -- |   return (sum ds)
+        -- | ```
         lexeme           :: forall a. ParserT s m a -> ParserT s m a,
-        -- | Parses any white space. White space consists of /zero/ or more
-        -- occurrences of a 'space', a line comment or a block (multi
-        -- line) comment. Block comments may be nested. How comments are
-        -- started and ended is defined in the 'LanguageDef'
-        -- that is passed to 'makeTokenParser'.
+        -- | Parses any white space. White space consists of *zero* or more
+        -- | occurrences of a `space`, a line comment or a block (multi
+        -- | line) comment. Block comments may be nested. How comments are
+        -- | started and ended is defined in the `LanguageDef`
+        -- | that is passed to `makeTokenParser`.
         whiteSpace       :: ParserT s m Unit,
-        -- | Lexeme parser @parens p@ parses @p@ enclosed in parenthesis,
-        -- returning the value of @p@.
+        -- | Lexeme parser `parens p` parses `p` enclosed in parenthesis,
+        -- | returning the value of `p`.
         parens           :: forall a. ParserT s m a -> ParserT s m a,
-        -- | Lexeme parser @braces p@ parses @p@ enclosed in braces (\'{\' and
-        -- \'}\'), returning the value of @p@.
+        -- | Lexeme parser `braces p` parses `p` enclosed in braces (`{` and
+        -- | `}`), returning the value of `p`.
         braces           :: forall a. ParserT s m a -> ParserT s m a,
-        -- | Lexeme parser @angles p@ parses @p@ enclosed in angle brackets (\'\<\'
-        -- and \'>\'), returning the value of @p@.
+        -- | Lexeme parser `angles p` parses `p` enclosed in angle brackets (`<`
+        -- | and `>`), returning the value of `p`.
         angles           :: forall a. ParserT s m a -> ParserT s m a,
-        -- | Lexeme parser @brackets p@ parses @p@ enclosed in brackets (\'[\'
-        -- and \']\'), returning the value of @p@.
+        -- | Lexeme parser `brackets p` parses `p` enclosed in brackets (`[`
+        -- | and `]`), returning the value of `p`.
         brackets         :: forall a. ParserT s m a -> ParserT s m a,
-        -- | Lexeme parser |semi| parses the character \';\' and skips any
-        -- trailing white space. Returns the string \";\".
+        -- | Lexeme parser `semi` parses the character `;` and skips any
+        -- | trailing white space. Returns the string `;`.
         semi             :: ParserT s m String,
-        -- | Lexeme parser @comma@ parses the character \',\' and skips any
-        -- trailing white space. Returns the string \",\".
+        -- | Lexeme parser `comma` parses the character `,` and skips any
+        -- | trailing white space. Returns the string `,`.
         comma            :: ParserT s m String,
-        -- | Lexeme parser @colon@ parses the character \':\' and skips any
-        -- trailing white space. Returns the string \":\".
+        -- | Lexeme parser `colon` parses the character `:` and skips any
+        -- | trailing white space. Returns the string `:`.
         colon            :: ParserT s m String,
-        -- | Lexeme parser @dot@ parses the character \'.\' and skips any
-        -- trailing white space. Returns the string \".\".
+        -- | Lexeme parser `dot` parses the character `.` and skips any
+        -- | trailing white space. Returns the string `.`.
         dot              :: ParserT s m String,
-        -- | Lexeme parser @semiSep p@ parses /zero/ or more occurrences of @p@
-        -- separated by 'semi'. Returns a list of values returned by
-        -- @p@.
+        -- | Lexeme parser `semiSep p` parses *zero* or more occurrences of `p`
+        -- | separated by `semi`. Returns a list of values returned by
+        -- | `p`.
         semiSep          :: forall a . ParserT s m a -> ParserT s m (List a),
-        -- | Lexeme parser @semiSep1 p@ parses /one/ or more occurrences of @p@
-        -- separated by 'semi'. Returns a list of values returned by @p@.
+        -- | Lexeme parser `semiSep1 p` parses *one* or more occurrences of `p`
+        -- | separated by `semi`. Returns a list of values returned by `p`.
         semiSep1         :: forall a . ParserT s m a -> ParserT s m (List a),
-        -- | Lexeme parser @commaSep p@ parses /zero/ or more occurrences of
-        -- @p@ separated by 'comma'. Returns a list of values returned
-        -- by @p@.
+        -- | Lexeme parser `commaSep p` parses *zero* or more occurrences of
+        -- | `p` separated by `comma`. Returns a list of values returned
+        -- | by `p`.
         commaSep         :: forall a . ParserT s m a -> ParserT s m (List a),
-        -- | Lexeme parser @commaSep1 p@ parses /one/ or more occurrences of
-        -- @p@ separated by 'comma'. Returns a list of values returned
-        -- by @p@.
+        -- | Lexeme parser `commaSep1 p` parses *one* or more occurrences of
+        -- | `p` separated by `comma`. Returns a list of values returned
+        -- | by `p`.
         commaSep1        :: forall a . ParserT s m a -> ParserT s m (List a)
     }
 
@@ -271,36 +272,34 @@ type GenTokenParser s m
 -- Given a LanguageDef, create a token parser.
 -----------------------------------------------------------
 
--- | The expression @makeTokenParser language@ creates a 'GenTokenParser'
--- record that contains lexical parsers that are
--- defined using the definitions in the @language@ record.
---
--- The use of this function is quite stylized - one imports the
--- appropiate language definition and selects the lexical parsers that
--- are needed from the resulting 'GenTokenParser'.
---
--- >  module Main where
--- >
--- >  import Text.Parsec
--- >  import qualified Text.Parsec.Token as P
--- >  import Text.Parsec.Language (haskellDef)
--- >
--- >  -- The parser
--- >  ...
--- >
--- >  expr  =   parens expr
--- >        <|> identifier
--- >        <|> ...
--- >
--- >
--- >  -- The lexer
--- >  lexer       = P.makeTokenParser haskellDef
--- >
--- >  parens      = P.parens lexer
--- >  braces      = P.braces lexer
--- >  identifier  = P.identifier lexer
--- >  reserved    = P.reserved lexer
--- >  ...
+-- | The expression `makeTokenParser language` creates a `GenTokenParser`
+-- | record that contains lexical parsers that are
+-- | defined using the definitions in the `language` record.
+-- |
+-- | The use of this function is quite stylized - one imports the
+-- | appropiate language definition and selects the lexical parsers that
+-- | are needed from the resulting `GenTokenParser`.
+-- |
+-- | ```purescript
+-- | module Main where
+-- |
+-- | import Text.Parsing.Parser.Language (haskellDef)
+-- | import Text.Parsing.Parser.Token (makeTokenParser)
+-- |
+-- | -- The parser
+-- | expr = parens expr
+-- |    <|> identifier
+-- |    <|> ...
+-- |
+-- |
+-- | -- The lexer
+-- | tokenParser = makeTokenParser haskellDef
+-- | parens      = tokenParser.parens
+-- | braces      = tokenParser.braces
+-- | identifier  = tokenParser.identifier
+-- | reserved    = tokenParser.reserved
+-- | ...
+-- | ```
 makeTokenParser :: forall m . (Monad m) => GenLanguageDef String m -> GenTokenParser String m
 makeTokenParser (LanguageDef languageDef)
     = { identifier: identifier
@@ -692,7 +691,8 @@ makeTokenParser (LanguageDef languageDef)
 
 
 -- ================================================================================ --
--- The following functions should really be in the where-clause of makeTokenParser. --
+-- The following functions should really be in the where-clause of makeTokenParser, --
+-- but they can't go there because they are mutually recursive.                     --
 -- ================================================================================ --
 
 -----------------------------------------------------------
@@ -775,23 +775,31 @@ inCommentSingle (LanguageDef languageDef) =
 -- Helper functions that should maybe go in Text.Parsing.Parser.String --
 -------------------------------------------------------------------------
 
+-- | Parse a digit.  Matches any char that satisfies `Data.Char.Unicode.isDigit`.
 digit :: forall m . (Monad m) => ParserT String m Char
 digit = satisfy isDigit <?> "digit"
 
+-- | Parse a hex digit.  Matches any char that satisfies `Data.Char.Unicode.isHexDigit`.
 hexDigit :: forall m . (Monad m) => ParserT String m Char
 hexDigit = satisfy isHexDigit <?> "hex digit"
 
+-- | Parse an octal digit.  Matches any char that satisfies `Data.Char.Unicode.isOctDigit`.
 octDigit :: forall m . (Monad m) => ParserT String m Char
 octDigit = satisfy isOctDigit <?> "oct digit"
 
+-- | Parse an uppercase letter.  Matches any char that satisfies `Data.Char.Unicode.isUpper`.
 upper :: forall m . (Monad m) => ParserT String m Char
 upper = satisfy isUpper <?> "uppercase letter"
 
+-- | Parse a space character.  Matches any char that satisfies `Data.Char.Unicode.isSpace`.
 space :: forall m . (Monad m) => ParserT String m Char
 space = satisfy isSpace <?> "space"
 
+-- | Parse an alphabetical character.  Matches any char that satisfies `Data.Char.Unicode.isAlpha`.
 letter :: forall m . (Monad m) => ParserT String m Char
 letter = satisfy isAlpha <?> "letter"
 
+-- | Parse an alphabetical or numerical character.
+-- | Matches any char that satisfies `Data.Char.Unicode.isAlphaNum`.
 alphaNum :: forall m . (Monad m) => ParserT String m Char
 alphaNum = satisfy isAlphaNum <?> "letter or digit"

--- a/src/Text/Parsing/Parser/Token.purs
+++ b/src/Text/Parsing/Parser/Token.purs
@@ -4,15 +4,31 @@ module Text.Parsing.Parser.Token where
 
 import Prelude
 
+import Data.Array as Array
+import Data.Char (fromCharCode, toCharCode)
+import Data.Char.Unicode (digitToInt, isAlpha, isAlphaNum, isDigit, isHexDigit, isOctDigit, isSpace, isUpper)
+import Data.Char.Unicode as Unicode
+import Data.String
 import Data.Either
+import Data.Foldable
+import Data.Functor
+import Data.Identity
+import Data.Int
 import Data.List (List(..))
+import Data.Maybe
+import Data.Tuple
 
+import Control.Alt
+import Control.Apply
+import Control.Lazy
 import Control.Monad.State.Class hiding (get)
 import Control.MonadPlus
+import Math (pow)
 
 import Text.Parsing.Parser
 import Text.Parsing.Parser.Combinators
 import Text.Parsing.Parser.Pos
+import Text.Parsing.Parser.String
 
 -- | Create a parser which returns the first token in the stream.
 token :: forall m a. (Monad m) => (a -> Position) -> ParserT (List a) m a
@@ -31,3 +47,732 @@ when tokpos f = try $ do
 -- | Match the specified token at the head of the stream.
 match :: forall a m. (Monad m, Eq a) => (a -> Position) -> a -> ParserT (List a) m a
 match tokpos tok = when tokpos (== tok)
+
+type LanguageDef = GenLanguageDef String Identity
+
+-- | The @GenLanguageDef@ type is a record that contains all parameterizable
+-- features of the "Text.Parsec.Token" module. The module "Text.Parsec.Language"
+-- contains some default definitions.
+newtype GenLanguageDef s m
+    = LanguageDef {
+    -- | Describes the start of a block comment. Use the empty string if the
+    -- language doesn't support block comments. For example \"\/*\".
+    commentStart   :: String,
+    -- | Describes the end of a block comment. Use the empty string if the
+    -- language doesn't support block comments. For example \"*\/\".
+    commentEnd     :: String,
+    -- | Describes the start of a line comment. Use the empty string if the
+    -- language doesn't support line comments. For example \"\/\/\".
+    commentLine    :: String,
+    -- | Set to 'True' if the language supports nested block comments.
+    nestedComments :: Boolean,
+    -- | This parser should accept any start characters of identifiers. For
+    -- example @letter \<|> char \'_\'@.
+    identStart     :: ParserT s m Char,
+    -- | This parser should accept any legal tail characters of identifiers.
+    -- For example @alphaNum \<|> char \'_\'@.
+    identLetter    :: ParserT s m Char,
+    -- | This parser should accept any start characters of operators. For
+    -- example @oneOf \":!#$%&*+.\/\<=>?\@\\\\^|-~\"@
+    opStart        :: ParserT s m Char,
+    -- | This parser should accept any legal tail characters of operators.
+    -- Note that this parser should even be defined if the language doesn't
+    -- support user-defined operators, or otherwise the 'reservedOp'
+    -- parser won't work correctly.
+    opLetter       :: ParserT s m Char,
+    -- | The list of reserved identifiers.
+    reservedNames  :: Array String,
+    -- | The list of reserved operators.
+    reservedOpNames:: Array String,
+    -- | Set to 'True' if the language is case sensitive.
+    caseSensitive  :: Boolean
+    }
+
+unGenLanguageDef :: forall s m . GenLanguageDef s m -> { caseSensitive :: Boolean
+                                                       , reservedOpNames :: Array String
+                                                       , reservedNames :: Array String
+                                                       , opLetter :: ParserT s m Char
+                                                       , opStart :: ParserT s m Char
+                                                       , identLetter :: ParserT s m Char
+                                                       , identStart :: ParserT s m Char
+                                                       , nestedComments :: Boolean
+                                                       , commentLine :: String
+                                                       , commentEnd :: String
+                                                       , commentStart :: String
+                                                       }
+unGenLanguageDef (LanguageDef langDef) = langDef
+
+-----------------------------------------------------------
+-- A first class module: TokenParser
+-----------------------------------------------------------
+
+type TokenParser = GenTokenParser String Identity
+
+-- | The type of the record that holds lexical parsers that work on
+-- @s@ streams over a monad @m@.
+
+type GenTokenParser s m
+    = {
+        -- | This lexeme parser parses a legal identifier. Returns the identifier
+        -- string. This parser will fail on identifiers that are reserved
+        -- words. Legal identifier (start) characters and reserved words are
+        -- defined in the 'LanguageDef' that is passed to
+        -- 'makeTokenParser'. An @identifier@ is treated as
+        -- a single token using 'try'.
+        identifier       :: ParserT s m String,
+        -- | The lexeme parser @reserved name@ parses @symbol
+        -- name@, but it also checks that the @name@ is not a prefix of a
+        -- valid identifier. A @reserved@ word is treated as a single token
+        -- using 'try'.
+        reserved         :: String -> ParserT s m Unit,
+        -- | This lexeme parser parses a legal operator. Returns the name of the
+        -- operator. This parser will fail on any operators that are reserved
+        -- operators. Legal operator (start) characters and reserved operators
+        -- are defined in the 'LanguageDef' that is passed to
+        -- 'makeTokenParser'. An @operator@ is treated as a
+        -- single token using 'try'.
+        operator         :: ParserT s m String,
+        -- |The lexeme parser @reservedOp name@ parses @symbol
+        -- name@, but it also checks that the @name@ is not a prefix of a
+        -- valid operator. A @reservedOp@ is treated as a single token using
+        -- 'try'.
+        reservedOp       :: String -> ParserT s m Unit,
+        -- | This lexeme parser parses a single literal character. Returns the
+        -- literal character value. This parsers deals correctly with escape
+        -- sequences. The literal character is parsed according to the grammar
+        -- rules defined in the Haskell report (which matches most programming
+        -- languages quite closely).
+        charLiteral      :: ParserT s m Char,
+        -- | This lexeme parser parses a literal string. Returns the literal
+        -- string value. This parsers deals correctly with escape sequences and
+        -- gaps. The literal string is parsed according to the grammar rules
+        -- defined in the Haskell report (which matches most programming
+        -- languages quite closely).
+        stringLiteral    :: ParserT s m String,
+        -- | This lexeme parser parses a natural number (a positive whole
+        -- number). Returns the value of the number. The number can be
+        -- specified in 'decimal', 'hexadecimal' or
+        -- 'octal'. The number is parsed according to the grammar
+        -- rules in the Haskell report.
+        natural          :: ParserT s m Int,
+        -- | This lexeme parser parses an integer (a whole number). This parser
+        -- is like 'natural' except that it can be prefixed with
+        -- sign (i.e. \'-\' or \'+\'). Returns the value of the number. The
+        -- number can be specified in 'decimal', 'hexadecimal'
+        -- or 'octal'. The number is parsed according
+        -- to the grammar rules in the Haskell report.
+        integer          :: ParserT s m Int,
+        -- | This lexeme parser parses a floating point value. Returns the value
+        -- of the number. The number is parsed according to the grammar rules
+        -- defined in the Haskell report.
+        float            :: ParserT s m Number,
+        -- | This lexeme parser parses either 'natural' or a 'float'.
+        -- Returns the value of the number. This parsers deals with
+        -- any overlap in the grammar rules for naturals and floats. The number
+        -- is parsed according to the grammar rules defined in the Haskell report.
+        naturalOrFloat   :: ParserT s m (Either Int Number),
+        -- | Parses a positive whole number in the decimal system. Returns the
+        -- value of the number.
+        decimal          :: ParserT s m Int,
+        -- | Parses a positive whole number in the hexadecimal system. The number
+        -- should be prefixed with \"0x\" or \"0X\". Returns the value of the
+        -- number.
+        hexadecimal      :: ParserT s m Int,
+        -- | Parses a positive whole number in the octal system. The number
+        -- should be prefixed with \"0o\" or \"0O\". Returns the value of the
+        -- number.
+        octal            :: ParserT s m Int,
+        -- | Lexeme parser @symbol s@ parses 'string' @s@ and skips
+        -- trailing white space.
+        symbol           :: String -> ParserT s m String,
+        -- | @lexeme p@ first applies parser @p@ and than the 'whiteSpace'
+        -- parser, returning the value of @p@. Every lexical
+        -- token (lexeme) is defined using @lexeme@, this way every parse
+        -- starts at a point without white space. Parsers that use @lexeme@ are
+        -- called /lexeme/ parsers in this document.
+        --
+        -- The only point where the 'whiteSpace' parser should be
+        -- called explicitly is the start of the main parser in order to skip
+        -- any leading white space.
+        --
+        -- >    mainParser  = do{ whiteSpace
+        -- >                     ; ds <- many (lexeme digit)
+        -- >                     ; eof
+        -- >                     ; return (sum ds)
+        -- >                     }
+        lexeme           :: forall a. ParserT s m a -> ParserT s m a,
+        -- | Parses any white space. White space consists of /zero/ or more
+        -- occurrences of a 'space', a line comment or a block (multi
+        -- line) comment. Block comments may be nested. How comments are
+        -- started and ended is defined in the 'LanguageDef'
+        -- that is passed to 'makeTokenParser'.
+        whiteSpace       :: ParserT s m Unit,
+        -- | Lexeme parser @parens p@ parses @p@ enclosed in parenthesis,
+        -- returning the value of @p@.
+        parens           :: forall a. ParserT s m a -> ParserT s m a,
+        -- | Lexeme parser @braces p@ parses @p@ enclosed in braces (\'{\' and
+        -- \'}\'), returning the value of @p@.
+        braces           :: forall a. ParserT s m a -> ParserT s m a,
+        -- | Lexeme parser @angles p@ parses @p@ enclosed in angle brackets (\'\<\'
+        -- and \'>\'), returning the value of @p@.
+        angles           :: forall a. ParserT s m a -> ParserT s m a,
+        -- | Lexeme parser @brackets p@ parses @p@ enclosed in brackets (\'[\'
+        -- and \']\'), returning the value of @p@.
+        brackets         :: forall a. ParserT s m a -> ParserT s m a,
+        -- | Lexeme parser |semi| parses the character \';\' and skips any
+        -- trailing white space. Returns the string \";\".
+        semi             :: ParserT s m String,
+        -- | Lexeme parser @comma@ parses the character \',\' and skips any
+        -- trailing white space. Returns the string \",\".
+        comma            :: ParserT s m String,
+        -- | Lexeme parser @colon@ parses the character \':\' and skips any
+        -- trailing white space. Returns the string \":\".
+        colon            :: ParserT s m String,
+        -- | Lexeme parser @dot@ parses the character \'.\' and skips any
+        -- trailing white space. Returns the string \".\".
+        dot              :: ParserT s m String,
+        -- | Lexeme parser @semiSep p@ parses /zero/ or more occurrences of @p@
+        -- separated by 'semi'. Returns a list of values returned by
+        -- @p@.
+        semiSep          :: forall a . ParserT s m a -> ParserT s m (List a),
+        -- | Lexeme parser @semiSep1 p@ parses /one/ or more occurrences of @p@
+        -- separated by 'semi'. Returns a list of values returned by @p@.
+        semiSep1         :: forall a . ParserT s m a -> ParserT s m (List a),
+        -- | Lexeme parser @commaSep p@ parses /zero/ or more occurrences of
+        -- @p@ separated by 'comma'. Returns a list of values returned
+        -- by @p@.
+        commaSep         :: forall a . ParserT s m a -> ParserT s m (List a),
+        -- | Lexeme parser @commaSep1 p@ parses /one/ or more occurrences of
+        -- @p@ separated by 'comma'. Returns a list of values returned
+        -- by @p@.
+        commaSep1        :: forall a . ParserT s m a -> ParserT s m (List a)
+    }
+
+-----------------------------------------------------------
+-- Given a LanguageDef, create a token parser.
+-----------------------------------------------------------
+
+-- | The expression @makeTokenParser language@ creates a 'GenTokenParser'
+-- record that contains lexical parsers that are
+-- defined using the definitions in the @language@ record.
+--
+-- The use of this function is quite stylized - one imports the
+-- appropiate language definition and selects the lexical parsers that
+-- are needed from the resulting 'GenTokenParser'.
+--
+-- >  module Main where
+-- >
+-- >  import Text.Parsec
+-- >  import qualified Text.Parsec.Token as P
+-- >  import Text.Parsec.Language (haskellDef)
+-- >
+-- >  -- The parser
+-- >  ...
+-- >
+-- >  expr  =   parens expr
+-- >        <|> identifier
+-- >        <|> ...
+-- >
+-- >
+-- >  -- The lexer
+-- >  lexer       = P.makeTokenParser haskellDef
+-- >
+-- >  parens      = P.parens lexer
+-- >  braces      = P.braces lexer
+-- >  identifier  = P.identifier lexer
+-- >  reserved    = P.reserved lexer
+-- >  ...
+makeTokenParser :: forall m . (Monad m) => GenLanguageDef String m -> GenTokenParser String m
+makeTokenParser (LanguageDef languageDef)
+    = { identifier: identifier
+      , reserved: reserved
+      , operator: operator
+      , reservedOp: reservedOp
+
+      , charLiteral: charLiteral
+      , stringLiteral: stringLiteral
+      , natural: natural
+      , integer: integer
+      , float: float
+      , naturalOrFloat: naturalOrFloat
+      , decimal: decimal
+      , hexadecimal: hexadecimal
+      , octal: octal
+
+      , symbol: symbol
+      , lexeme: lexeme
+      , whiteSpace: whiteSpace' (LanguageDef languageDef)
+
+      , parens: parens
+      , braces: braces
+      , angles: angles
+      , brackets: brackets
+      , semi: semi
+      , comma: comma
+      , colon: colon
+      , dot: dot
+      , semiSep: semiSep
+      , semiSep1: semiSep1
+      , commaSep: commaSep
+      , commaSep1: commaSep1
+      }
+  where
+    -----------------------------------------------------------
+    -- Bracketing
+    -----------------------------------------------------------
+    parens :: forall a . ParserT String m a -> ParserT String m a
+    parens p = between (symbol "(") (symbol ")") p
+
+    braces :: forall a . ParserT String m a -> ParserT String m a
+    braces p = between (symbol "{") (symbol "}") p
+
+    angles :: forall a . ParserT String m a -> ParserT String m a
+    angles p = between (symbol "<") (symbol ">") p
+
+    brackets :: forall a . ParserT String m a -> ParserT String m a
+    brackets p = between (symbol "[") (symbol "]") p
+
+    semi :: ParserT String m String
+    semi = symbol ";"
+
+    comma :: ParserT String m String
+    comma = symbol ","
+
+    dot :: ParserT String m String
+    dot = symbol "."
+
+    colon :: ParserT String m String
+    colon = symbol ":"
+
+    commaSep :: forall a . ParserT String m a -> ParserT String m (List a)
+    commaSep p = sepBy p comma
+
+    semiSep :: forall a . ParserT String m a -> ParserT String m (List a)
+    semiSep p = sepBy p semi
+
+    commaSep1 :: forall a . ParserT String m a -> ParserT String m (List a)
+    commaSep1 p = sepBy1 p comma
+
+    semiSep1 :: forall a . ParserT String m a -> ParserT String m (List a)
+    semiSep1 p = sepBy1 p semi
+
+    -----------------------------------------------------------
+    -- Chars & Strings
+    -----------------------------------------------------------
+    charLiteral :: ParserT String m Char
+    charLiteral = lexeme go <?> "character"
+      where
+        go :: ParserT String m Char
+        go = between (char '\'') (char '\'' <?> "end of character") characterChar
+
+    characterChar :: ParserT String m Char
+    characterChar = charLetter <|> charEscape <?> "literal character"
+
+    charEscape :: ParserT String m Char
+    charEscape = char '\\' *> escapeCode
+
+    charLetter :: ParserT String m Char
+    charLetter = satisfy \c -> (c /= '\'') && (c /= '\\') && (c > '\026')
+
+    stringLiteral :: ParserT String m String
+    stringLiteral = lexeme (go <?> "literal string")
+      where
+        go :: ParserT String m String
+        go = do
+            maybeCharArray <- between (char '"') (char '"' <?> "end of string") (Array.many stringChar)
+            pure $ fromCharArray $ foldr folder [] maybeCharArray
+
+        folder :: Maybe Char -> Array Char -> Array Char
+        folder Nothing charArray = charArray
+        -- TODO: This is O(n).
+        folder (Just c) charArray = Array.cons c charArray
+
+
+    stringChar :: ParserT String m (Maybe Char)
+    stringChar = (Just <$> stringLetter)
+             <|> stringEscape
+             <?> "string character"
+
+    stringLetter :: ParserT String m Char
+    stringLetter = satisfy (\c -> (c /= '"') && (c /= '\\') && (c > '\026'))
+
+    stringEscape :: ParserT String m (Maybe Char)
+    stringEscape = do
+        char '\\'
+        (escapeGap $> Nothing) <|> (escapeEmpty $> Nothing) <|> (Just <$> escapeCode)
+
+    escapeEmpty :: ParserT String m Char
+    escapeEmpty = char '&'
+
+    escapeGap :: ParserT String m Char
+    escapeGap = Array.some space *> char '\\' <?> "end of string gap"
+
+    -- -- escape codes
+    escapeCode :: ParserT String m Char
+    escapeCode = charEsc <|> charNum <|> charAscii <|> charControl
+             <?> "escape code"
+
+    charControl :: ParserT String m Char
+    charControl = do
+        char '^'
+        code <- upper
+        pure <<< fromCharCode $ toCharCode code - toCharCode 'A' + 1
+
+    charNum :: ParserT String m Char
+    charNum = do
+        code <- decimal
+           <|> ( char 'o' *> number 8 octDigit )
+           <|> ( char 'x' *> number 16 hexDigit )
+        if code > 0x10FFFF
+           then fail "invalid escape sequence"
+           else pure $ fromCharCode code
+
+    charEsc :: ParserT String m Char
+    charEsc = choice (map parseEsc escMap)
+      where
+        parseEsc :: Tuple Char Char -> ParserT String m Char
+        parseEsc (Tuple c code) = char c $> code
+
+    charAscii :: ParserT String m Char
+    charAscii = choice (map parseAscii asciiMap)
+      where
+        parseAscii :: Tuple String Char -> ParserT String m Char
+        parseAscii (Tuple asc code) = try $ string asc $> code
+
+    -- escape code tables
+    escMap :: Array (Tuple Char Char)
+    escMap = Array.zip [  'a',  'b',  'f',  'n',  'r',  't',  'v', '\\', '\"', '\'' ]
+                       [ '\a', '\b', '\f', '\n', '\r', '\t', '\v', '\\', '\"', '\'' ]
+
+    asciiMap :: Array (Tuple String Char)
+    asciiMap = Array.zip (ascii3codes <> ascii2codes) (ascii3 <> ascii2)
+
+    ascii2codes :: Array String
+    ascii2codes = [ "BS", "HT", "LF", "VT", "FF", "CR", "SO", "SI", "EM", "FS", "GS", "RS", "US", "SP" ]
+
+    ascii3codes :: Array String
+    ascii3codes = [ "NUL", "SOH", "STX", "ETX", "EOT", "ENQ", "ACK", "BEL"
+                  , "DLE", "DC1", "DC2", "DC3", "DC4", "NAK", "SYN", "ETB"
+                  , "CAN", "SUB", "ESC", "DEL"
+                  ]
+
+    ascii2 :: Array Char
+    ascii2 = [ '\BS', '\HT', '\LF', '\VT', '\FF', '\CR', '\SO', '\SI'
+             , '\EM', '\FS', '\GS', '\RS', '\US', '\SP'
+             ]
+
+    ascii3 :: Array Char
+    ascii3 = [ '\NUL', '\SOH', '\STX', '\ETX', '\EOT', '\ENQ', '\ACK'
+             , '\BEL', '\DLE', '\DC1', '\DC2', '\DC3', '\DC4', '\NAK'
+             , '\SYN', '\ETB', '\CAN', '\SUB', '\ESC', '\DEL'
+             ]
+
+    -----------------------------------------------------------
+    -- Numbers
+    -----------------------------------------------------------
+
+    naturalOrFloat :: ParserT String m (Either Int Number)
+    naturalOrFloat = lexeme (natFloat) <?> "number"
+
+    float :: ParserT String m Number
+    float = lexeme floating <?> "float"
+
+    integer :: ParserT String m Int
+    integer = lexeme int <?> "integer"
+
+    natural :: ParserT String m Int
+    natural = lexeme nat <?> "natural"
+
+    -- floats
+    floating :: ParserT String m Number
+    floating = decimal >>= fractExponent
+
+    natFloat :: ParserT String m (Either Int Number)
+    natFloat = char '0' *> zeroNumFloat
+           <|> decimalFloat
+
+    zeroNumFloat :: ParserT String m (Either Int Number)
+    zeroNumFloat = Left <$> (hexadecimal <|> octal)
+               <|> decimalFloat
+               <|> fractFloat 0
+               <|> pure (Left 0)
+
+    decimalFloat :: ParserT String m (Either Int Number)
+    decimalFloat = do
+        n <- decimal
+        option (Left n) (fractFloat n)
+
+    fractFloat :: forall a . Int -> ParserT String m (Either a Number)
+    fractFloat n = Right <$> fractExponent n
+
+    fractExponent :: Int -> ParserT String m Number
+    fractExponent n = fractExponent' <|> justExponent
+      where
+        fractExponent' :: ParserT String m Number
+        fractExponent' = do
+            fract <- fraction
+            expo  <- option 1.0 exponent'
+            pure $ (toNumber n + fract) * expo
+
+        justExponent :: ParserT String m Number
+        justExponent = do
+            expo <- exponent'
+            pure $ (toNumber n * expo)
+
+    fraction :: ParserT String m Number
+    fraction = "fraction" <??> do
+        char '.'
+        digits <- Array.some digit <?> "fraction"
+        maybe (fail "not digit") pure $ foldr op (Just 0.0) digits
+      where
+        op :: Char -> Maybe Number -> Maybe Number
+        op _ Nothing  = Nothing
+        op d (Just f) = do
+            int' <- digitToInt d
+            pure $ ( f + toNumber int' ) / 10.0
+
+    exponent' :: ParserT String m Number
+    exponent' = "exponent" <??> do
+        oneOf ['e', 'E']
+        f <- sign
+        e <- decimal <?> "exponent"
+        pure $ power (f e)
+      where
+        power :: Int -> Number
+        power e | e < 0      = 1.0 / power (-e)
+                | otherwise  = 10.0 `pow` toNumber e
+
+    -- integers and naturals
+    int :: ParserT String m Int
+    int = do
+        f <- lexeme sign
+        n <- nat
+        pure $ f n
+
+    sign :: forall a . (Ring a) => ParserT String m (a -> a)
+    sign = (char '-' $> negate)
+       <|> (char '+' $> id)
+       <|> pure id
+
+    nat :: ParserT String m Int
+    nat = zeroNumber <|> decimal
+
+    zeroNumber :: ParserT String m Int
+    zeroNumber = char '0' *>
+                    ( hexadecimal <|> octal <|> decimal <|> pure 0 ) <?> ""
+
+    decimal :: ParserT String m Int
+    decimal = number 10 digit
+
+    hexadecimal :: ParserT String m Int
+    hexadecimal = oneOf ['x', 'X'] *> number 16 hexDigit
+
+    octal :: ParserT String m Int
+    octal = oneOf ['o', 'O'] *> number 8 octDigit
+
+    number :: Int -> ParserT String m Char -> ParserT String m Int
+    number base baseDigit = do
+        digits <- Array.some baseDigit
+        maybe (fail "not digits") pure $ foldl folder (Just 0) digits
+      where
+        folder :: Maybe Int -> Char -> Maybe Int
+        folder Nothing _ = Nothing
+        folder (Just x) d = ((base*x) +) <$> digitToInt d
+
+    -----------------------------------------------------------
+    -- Operators & reserved ops
+    -----------------------------------------------------------
+
+    reservedOp :: String -> ParserT String m Unit
+    reservedOp name = lexeme $ try go
+      where
+        go :: ParserT String m Unit
+        go = do
+            string name
+            notFollowedBy languageDef.opLetter <?> "end of " <> name
+
+    operator :: ParserT String m String
+    operator = lexeme $ try go
+      where
+        go :: ParserT String m String
+        go = do
+            name <- oper
+            if (isReservedOp name)
+                then fail ("reserved operator " <> name)
+                else pure name
+
+    oper :: ParserT String m String
+    oper = go <?> "operator"
+      where
+        go :: ParserT String m String
+        go = do
+            c <- languageDef.opStart
+            cs <- Array.many languageDef.opLetter
+            pure $ fromChar c <> fromCharArray cs
+
+    isReservedOp :: String -> Boolean
+    isReservedOp name = isReserved (Array.sort languageDef.reservedOpNames) name
+
+
+    -----------------------------------------------------------
+    -- Identifiers & Reserved words
+    -----------------------------------------------------------
+
+    reserved :: String -> ParserT String m Unit
+    reserved name = lexeme $ try go
+      where
+        go :: ParserT String m Unit
+        go = caseString name *> (notFollowedBy languageDef.identLetter <?> "end of " <> name)
+
+    caseString :: String -> ParserT String m String
+    caseString name | languageDef.caseSensitive = string name
+                    | otherwise                 = walk name $> name
+      where
+        walk :: String -> ParserT String m Unit
+        walk name' = case uncons name' of
+                        Nothing -> pure unit
+                        Just { head: c, tail: cs } -> (caseChar c <?> msg) *> walk cs
+
+        caseChar :: Char -> ParserT String m Char
+        caseChar c | isAlpha c = char (Unicode.toLower c) <|> char (Unicode.toUpper c)
+                   | otherwise = char c
+
+        msg :: String
+        msg = show name
+
+
+    identifier :: ParserT String m String
+    identifier = lexeme $ try go
+      where
+        go :: ParserT String m String
+        go = do
+            name <- ident
+            if (isReservedName (LanguageDef languageDef) name)
+               then fail ("reserved word " ++ show name)
+               else pure name
+
+
+    ident :: ParserT String m String
+    ident = go <?> "identitfier"
+      where
+        go :: ParserT String m String
+        go = do
+            c <- languageDef.identStart
+            cs <- Array.many languageDef.identLetter
+            pure $ fromChar c <> fromCharArray cs
+
+
+    -----------------------------------------------------------
+    -- White space & symbols
+    -----------------------------------------------------------
+    symbol :: String -> ParserT String m String
+    symbol name = lexeme (string name)
+
+    lexeme :: forall a . ParserT String m a -> ParserT String m a
+    lexeme p = p <* whiteSpace' (LanguageDef languageDef)
+
+
+-- ================================================================================ --
+-- The following functions should really be in the where-clause of makeTokenParser. --
+-- ================================================================================ --
+
+-----------------------------------------------------------
+-- Identifiers & Reserved words
+-----------------------------------------------------------
+
+isReservedName :: forall m . (Monad m) => GenLanguageDef String m -> String -> Boolean
+isReservedName langDef@(LanguageDef languageDef) name =
+    isReserved (theReservedNames langDef) caseName
+  where
+    caseName | languageDef.caseSensitive  = name
+             | otherwise                  = toLower name
+
+isReserved :: Array String -> String -> Boolean
+isReserved names name =
+    case Array.uncons names of
+        Nothing -> false
+        Just { head: r, tail: rs } -> case (compare r name) of
+                                        LT  -> isReserved rs name
+                                        EQ  -> true
+                                        GT  -> false
+
+theReservedNames :: forall m . (Monad m) => GenLanguageDef String m -> Array String
+theReservedNames (LanguageDef languageDef)
+    | languageDef.caseSensitive = Array.sort languageDef.reservedNames
+    | otherwise                 = Array.sort $ map toLower languageDef.reservedNames
+
+-----------------------------------------------------------
+-- White space & symbols
+-----------------------------------------------------------
+
+whiteSpace' :: forall m . (Monad m) => GenLanguageDef String m -> ParserT String m Unit
+whiteSpace' langDef@(LanguageDef languageDef)
+    | null languageDef.commentLine && null languageDef.commentStart =
+        skipMany (simpleSpace <?> "")
+    | null languageDef.commentLine =
+        skipMany (simpleSpace <|> multiLineComment langDef <?> "")
+    | null languageDef.commentStart =
+        skipMany (simpleSpace <|> oneLineComment langDef <?> "")
+    | otherwise =
+        skipMany (simpleSpace <|> oneLineComment langDef <|> multiLineComment langDef <?> "")
+
+simpleSpace :: forall m . (Monad m) => ParserT String m Unit
+simpleSpace = skipMany1 (satisfy isSpace)
+
+oneLineComment :: forall m . (Monad m) => GenLanguageDef String m -> ParserT String m Unit
+oneLineComment (LanguageDef languageDef) =
+    try (string languageDef.commentLine) *> skipMany (satisfy (/= '\n'))
+
+multiLineComment :: forall m . (Monad m) => GenLanguageDef String m -> ParserT String m Unit
+multiLineComment langDef@(LanguageDef languageDef) =
+    try (string languageDef.commentStart) *> inComment langDef
+
+inComment :: forall m . (Monad m) => GenLanguageDef String m -> ParserT String m Unit
+inComment langDef@(LanguageDef languageDef) =
+    if languageDef.nestedComments then inCommentMulti langDef else inCommentSingle langDef
+
+inCommentMulti :: forall m . (Monad m) => GenLanguageDef String m -> ParserT String m Unit
+inCommentMulti langDef@(LanguageDef languageDef) =
+    fix \p -> ( void $ try (string languageDef.commentEnd) )
+          <|> ( multiLineComment langDef    *>  p )
+          <|> ( skipMany1 (noneOf startEnd) *> p )
+          <|> ( oneOf startEnd              *> p )
+          <?> "end of comment"
+  where
+    startEnd :: Array Char
+    startEnd   = toCharArray languageDef.commentEnd <> toCharArray languageDef.commentStart
+
+inCommentSingle :: forall m . (Monad m) => GenLanguageDef String m -> ParserT String m Unit
+inCommentSingle (LanguageDef languageDef) =
+    fix \p -> ( void $ try (string languageDef.commentEnd) )
+          <|> ( skipMany1 (noneOf startEnd) *> p )
+          <|> ( oneOf startEnd              *> p )
+          <?> "end of comment"
+  where
+    startEnd :: Array Char
+    startEnd = toCharArray languageDef.commentEnd <> toCharArray languageDef.commentStart
+
+-------------------------------------------------------------------------
+-- Helper functions that should maybe go in Text.Parsing.Parser.String --
+-------------------------------------------------------------------------
+
+digit :: forall m . (Monad m) => ParserT String m Char
+digit = satisfy isDigit <?> "digit"
+
+hexDigit :: forall m . (Monad m) => ParserT String m Char
+hexDigit = satisfy isHexDigit <?> "hex digit"
+
+octDigit :: forall m . (Monad m) => ParserT String m Char
+octDigit = satisfy isOctDigit <?> "oct digit"
+
+upper :: forall m . (Monad m) => ParserT String m Char
+upper = satisfy isUpper <?> "uppercase letter"
+
+space :: forall m . (Monad m) => ParserT String m Char
+space = satisfy isSpace <?> "space"
+
+letter :: forall m . (Monad m) => ParserT String m Char
+letter = satisfy isAlpha <?> "letter"
+
+alphaNum :: forall m . (Monad m) => ParserT String m Char
+alphaNum = satisfy isAlphaNum <?> "letter or digit"

--- a/src/Text/Parsing/Parser/Token.purs
+++ b/src/Text/Parsing/Parser/Token.purs
@@ -1,6 +1,25 @@
 -- | Functions for working with streams of tokens.
 
-module Text.Parsing.Parser.Token where
+module Text.Parsing.Parser.Token
+  ( token
+  , when
+  , match
+  , LanguageDef()
+  , GenLanguageDef(LanguageDef)
+  , unGenLanguageDef
+  , TokenParser()
+  , GenTokenParser()
+  , makeTokenParser
+  -- should these be exported?  Maybe they should go in a different module?
+  , digit
+  , hexDigit
+  , octDigit
+  , upper
+  , space
+  , letter
+  , alphaNum
+  )
+    where
 
 import Prelude
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -389,6 +389,31 @@ tokenParserCommaSep1Test = do
     -- no parse on empty string
     parseErrorTestPosition (testTokenParser.commaSep1 $ string "foo") "" $ mkPos 1
 
+haskellStyleTest :: TestM
+haskellStyleTest = do
+    let haskellTokParser = makeTokenParser haskellStyle
+
+    -- make sure haskell-style comments work
+    parseTest "hello {- comment\n -} fo_" "fo_" $ haskellTokParser.identifier *> haskellTokParser.identifier
+
+    -- make sure java-style comments do not work
+    parseErrorTestPosition
+        (haskellTokParser.identifier *> haskellTokParser.identifier)
+        "hello /* comment\n */ foo"
+        (mkPos 7)
+
+javaStyleTest :: TestM
+javaStyleTest = do
+    let javaTokParser = makeTokenParser javaStyle
+    -- make sure java-style comments work
+    parseTest "hello /* comment\n */ fo_" "fo_" $ javaTokParser.identifier *> javaTokParser.identifier
+
+    -- make sure haskell-style comments do not work
+    parseErrorTestPosition
+        (javaTokParser.identifier *> javaTokParser.identifier)
+        "hello {- comment\n -} foo"
+        (mkPos 7)
+
 main :: forall eff . Eff (console :: CONSOLE, assert :: ASSERT |eff) Unit
 main = do
 
@@ -462,3 +487,6 @@ main = do
   tokenParserSemiSep1Test
   tokenParserCommaSepTest
   tokenParserCommaSep1Test
+
+  haskellStyleTest
+  javaStyleTest

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -4,15 +4,14 @@ import Prelude
 
 import Data.Array (some)
 import Data.Either
-import Data.Identity
 import Data.Maybe
 import Data.Char (toString)
 import Data.String (fromCharArray)
-import Data.List (List(..), many, toList)
+import Data.List (List(..), fromFoldable, many, toList)
 import Data.Functor (($>))
+import Data.Tuple
 
 import Control.Alt
-import Control.Alternative
 import Control.Apply ((*>))
 import Control.Lazy
 
@@ -22,8 +21,9 @@ import Control.Monad.Eff.Console
 import Text.Parsing.Parser
 import Text.Parsing.Parser.Combinators
 import Text.Parsing.Parser.Expr
+import Text.Parsing.Parser.Language
 import Text.Parsing.Parser.String
-import Text.Parsing.Parser.Token
+import Text.Parsing.Parser.Token hiding (digit)
 import Text.Parsing.Parser.Pos
 
 import Test.Assert
@@ -38,13 +38,13 @@ nested = fix \p -> (do
 
 parseTest :: forall s a eff. (Show a, Eq a) => s -> a -> Parser s a -> Eff (console :: CONSOLE, assert :: ASSERT | eff) Unit
 parseTest input expected p = case runParser input p of
-  Right actual -> assert (expected == actual)
+  Right actual -> assert' ("expected: " <> show expected <> ", actual: " <> show actual) (expected == actual)
   Left err -> assert' ("error: " ++ show err) false
 
 parseErrorTestPosition :: forall s a eff. (Show a) => Parser s a -> s -> Position -> Eff (console :: CONSOLE, assert :: ASSERT | eff) Unit
 parseErrorTestPosition p input expected = case runParser input p of
   Right _ -> assert' "error: ParseError expected!" false
-  Left (ParseError { position: pos }) -> assert (expected == pos)
+  Left (ParseError { position: pos }) -> assert' ("expected: " <> show expected <> ", pos: " <> show pos) (expected == pos)
 
 opTest :: Parser String String
 opTest = chainl (toString <$> anyChar) (char '+' $> append) ""
@@ -68,6 +68,7 @@ exprTest = buildExprParser [ [ Infix (string "/" >>= \_ -> return (/)) AssocRigh
                            , [ Infix (string "+" >>= \_ -> return (+)) AssocRight ]
                            ] digit
 
+
 manySatisfyTest :: Parser String String
 manySatisfyTest = do
   r <- some $ satisfy (\s -> s /= '?')
@@ -89,6 +90,306 @@ isA :: TestToken -> Boolean
 isA A = true
 isA _ = false
 
+testTokenParser :: TokenParser
+testTokenParser = makeTokenParser haskellDef
+
+mkPos :: Int -> Position
+mkPos n = mkPos' n 1
+
+mkPos' :: Int -> Int -> Position
+mkPos' column line = Position { column: column, line: line }
+
+type TestM = forall eff . Eff (console :: CONSOLE, assert :: ASSERT | eff) Unit
+
+tokenParserIdentifierTest :: TestM
+tokenParserIdentifierTest = do
+    -- parse normal identifier
+    parseTest "hello" "hello" testTokenParser.identifier
+
+    -- error on reserved words
+    parseErrorTestPosition testTokenParser.identifier "let" $ mkPos 4
+
+    -- parse whitespace after identifier
+    parseTest "hello     twice   " "twice" (testTokenParser.identifier *> testTokenParser.identifier)
+
+    -- can't start identifiers with numbers
+    parseErrorTestPosition testTokenParser.identifier "3hello" $ mkPos 1
+
+    -- but numbers can be in the identifier
+    parseTest "h3ll0  " "h3ll0" testTokenParser.identifier
+
+    -- comments count as whitespace
+    parseTest "h3ll0  -- this is a comment\nbye {- this is another comment -}" (Tuple "h3ll0" "bye")
+        (Tuple <$> testTokenParser.identifier <*> testTokenParser.identifier)
+
+    -- multiline comments work well
+    parseTest "hello {- this \nis a comment -} bye" (Tuple "hello" "bye")
+        (Tuple <$> testTokenParser.identifier <*> testTokenParser.identifier)
+
+    -- nested comments are okay
+    parseTest "hello {- this {- \nis a comment -} foo -} bye" (Tuple "hello" "bye")
+        (Tuple <$> testTokenParser.identifier <*> testTokenParser.identifier)
+
+    -- fail on non-matching comments
+    parseErrorTestPosition testTokenParser.identifier "hello {-" $ mkPos 9
+
+
+tokenParserReservedTest :: TestM
+tokenParserReservedTest = do
+    -- parse reserved identifier
+    parseTest "forall" unit $ testTokenParser.reserved "forall"
+
+    -- fail on nonmatching reserved identifier
+    parseErrorTestPosition (testTokenParser.reserved "forall") "forall3" $ mkPos 7
+
+    -- fail on nonmatching reserved identifier
+    parseErrorTestPosition (testTokenParser.reserved "forall") "forall3" $ mkPos 7
+
+tokenParserOperatorTest :: TestM
+tokenParserOperatorTest = do
+    -- parse operator
+    parseTest "++" "++" testTokenParser.operator
+
+    -- fail on nonoperator
+    parseErrorTestPosition testTokenParser.operator "foo" $ mkPos 1
+
+    -- fail on reserved operator
+    parseErrorTestPosition testTokenParser.operator "=" $ mkPos 2
+
+-- TODO
+tokenParserReservedOpTest :: TestM
+tokenParserReservedOpTest = pure unit
+
+tokenParserCharLiteralTest :: TestM
+tokenParserCharLiteralTest = do
+    -- parse char literal
+    parseTest "'c'" 'c' testTokenParser.charLiteral
+
+    -- fail on slash
+    parseErrorTestPosition testTokenParser.charLiteral "'\'" $ mkPos 2
+
+    -- parse escape code
+    parseTest "'\\n'" '\n' testTokenParser.charLiteral
+
+    -- parse oct number
+    parseTest "'\\o101'" 'A' testTokenParser.charLiteral
+
+    -- parse hex number
+    parseTest "'\\x41'" 'A' testTokenParser.charLiteral
+
+    -- fail on bad oct
+    parseErrorTestPosition testTokenParser.charLiteral "'\\o389'" $ mkPos 5
+
+    -- parse ascii
+    parseTest "'\\^I'" '\t' testTokenParser.charLiteral
+
+tokenParserStringLiteralTest :: TestM
+tokenParserStringLiteralTest = do
+    -- parse string char
+    parseTest "\"hello\"" "hello" testTokenParser.stringLiteral
+
+    -- fail on non-operator
+    parseErrorTestPosition testTokenParser.stringLiteral "he\"llo" $ mkPos 1
+
+    -- parse string gap
+    parseTest "\"he\\       \\llo\"" "hello" testTokenParser.stringLiteral
+
+    -- parse string empty
+    parseTest "\"he\\&llo\"" "hello" testTokenParser.stringLiteral
+
+    -- parse string escape
+    parseTest "\"he\\nllo\"" "he\nllo" testTokenParser.stringLiteral
+
+tokenParserNaturalTest :: TestM
+tokenParserNaturalTest = do
+    -- parse natural
+    parseTest "1" 1 testTokenParser.natural
+
+    -- parse hex natural
+    parseTest "0xFF" 255 testTokenParser.natural
+
+    -- parse oct natural
+    parseTest "0o10  " 8 testTokenParser.natural
+
+    -- fail on nonoct
+    parseErrorTestPosition testTokenParser.natural "0o8" $ mkPos 3
+
+    -- fail on no digits
+    parseErrorTestPosition testTokenParser.natural "0o" $ mkPos 3
+
+tokenParserIntegerTest :: TestM
+tokenParserIntegerTest = do
+    -- parse integer
+    parseTest "100" 100 testTokenParser.integer
+
+    -- parse plus
+    parseTest "+200" 200 testTokenParser.integer
+
+    -- parse minus
+    parseTest "-      100" (-100) testTokenParser.integer
+
+tokenParserFloatTest :: TestM
+tokenParserFloatTest = do
+    -- parse float
+    parseTest "100.5" 100.5 testTokenParser.float
+
+    -- parse float with exponent
+    parseTest "100e1" 1000.0 testTokenParser.float
+
+    -- parse float with exponent
+    parseTest "100.5e1" 1005.0 testTokenParser.float
+
+    -- fail on nonfloat
+    parseErrorTestPosition testTokenParser.float "100.e1" $ mkPos 5
+
+-- TODO
+tokenParserNaturalOrFloatTest :: TestM
+tokenParserNaturalOrFloatTest = do
+    pure unit
+
+tokenParserDecimalTest :: TestM
+tokenParserDecimalTest = do
+    -- parse decimal
+    parseTest "0202" 202 testTokenParser.decimal
+
+    -- fail on nondecimal
+    parseErrorTestPosition testTokenParser.decimal "foo" $ mkPos 1
+
+-- TODO
+tokenParserHexadecimalTest :: TestM
+tokenParserHexadecimalTest = do
+    pure unit
+
+-- TODO
+tokenParserOctalTest :: TestM
+tokenParserOctalTest = do
+    pure unit
+
+tokenParserSymbolTest :: TestM
+tokenParserSymbolTest = do
+    -- parse symbol
+    parseTest "hello    " "hello" $ testTokenParser.symbol "hello"
+
+-- TODO
+tokenParserLexemeTest :: TestM
+tokenParserLexemeTest = do
+    pure unit
+
+-- TODO
+tokenParserWhiteSpaceTest :: TestM
+tokenParserWhiteSpaceTest = do
+    pure unit
+
+tokenParserParensTest :: TestM
+tokenParserParensTest = do
+    -- parse parens
+    parseTest "(hello)" "hello" $ testTokenParser.parens $ string "hello"
+
+    -- fail on non-closed parens
+    parseErrorTestPosition (testTokenParser.parens $ string "hello") "(hello" $ mkPos 7
+
+tokenParserBracesTest :: TestM
+tokenParserBracesTest = do
+    -- parse braces
+    parseTest "{hello}" "hello" $ testTokenParser.braces $ string "hello"
+
+    -- fail on non-closed braces
+    parseErrorTestPosition (testTokenParser.braces $ string "hello") "{hello" $ mkPos 7
+
+tokenParserAnglesTest :: TestM
+tokenParserAnglesTest = do
+    -- parse angles
+    parseTest "<hello>" "hello" $ testTokenParser.angles $ string "hello"
+
+    -- fail on non-closed angles
+    parseErrorTestPosition (testTokenParser.angles $ string "hello") "<hello" $ mkPos 7
+
+tokenParserBracketsTest :: TestM
+tokenParserBracketsTest = do
+    -- parse brackets
+    parseTest "[hello]" "hello" $ testTokenParser.brackets $ string "hello"
+
+    -- fail on non-closed brackets
+    parseErrorTestPosition (testTokenParser.brackets $ string "hello") "[hello" $ mkPos 7
+
+tokenParserSemiTest :: TestM
+tokenParserSemiTest = do
+    -- parse semicolon
+    parseTest ";" ";" testTokenParser.semi
+
+    -- fail on non-semicolon
+    parseErrorTestPosition testTokenParser.semi "a" $ mkPos 1
+
+tokenParserCommaTest :: TestM
+tokenParserCommaTest = do
+    -- parse comma
+    parseTest "," "," testTokenParser.comma
+
+    -- fail on non-comma
+    parseErrorTestPosition testTokenParser.comma "a" $ mkPos 1
+
+tokenParserColonTest :: TestM
+tokenParserColonTest = do
+    -- parse colon
+    parseTest ":" ":" testTokenParser.colon
+
+    -- fail on non-colon
+    parseErrorTestPosition testTokenParser.colon "a" $ mkPos 1
+
+tokenParserDotTest :: TestM
+tokenParserDotTest = do
+    -- parse dot
+    parseTest "." "." testTokenParser.dot
+
+    -- fail on non-dot
+    parseErrorTestPosition testTokenParser.dot "a" $ mkPos 1
+
+tokenParserSemiSepTest :: TestM
+tokenParserSemiSepTest = do
+    -- parse semi sep
+    parseTest "foo; foo" (fromFoldable ["foo", "foo"]) $ testTokenParser.semiSep $ string "foo"
+
+    -- parse semi sep with newline
+    parseTest "foo; \nfoo" (fromFoldable ["foo", "foo"]) $ testTokenParser.semiSep $ string "foo"
+
+    -- parse no semi sep
+    parseTest "" (fromFoldable []) $ testTokenParser.semiSep $ string "foo"
+    -- parseErrorTestPosition testTokenParser.operator "foo" $ mkPos 1
+
+tokenParserSemiSep1Test :: TestM
+tokenParserSemiSep1Test = do
+    -- parse semi sep1
+    parseTest "foo; foo" (fromFoldable ["foo", "foo"]) $ testTokenParser.semiSep1 $ string "foo"
+
+    -- parse semi sep1 with newline
+    parseTest "foo; \nfoo" (fromFoldable ["foo", "foo"]) $ testTokenParser.semiSep1 $ string "foo"
+
+    -- no parse on empty string
+    parseErrorTestPosition (testTokenParser.semiSep1 $ string "foo") "" $ mkPos 1
+
+tokenParserCommaSepTest :: TestM
+tokenParserCommaSepTest = do
+    -- parse comma sep
+    parseTest "foo, foo" (fromFoldable ["foo", "foo"]) $ testTokenParser.commaSep $ string "foo"
+
+    -- parse comma sep with newline
+    parseTest "foo, \nfoo" (fromFoldable ["foo", "foo"]) $ testTokenParser.commaSep $ string "foo"
+
+    -- parse no comma sep
+    parseTest "" (fromFoldable []) $ testTokenParser.commaSep $ string "foo"
+
+tokenParserCommaSep1Test :: TestM
+tokenParserCommaSep1Test = do
+    -- parse comma sep1
+    parseTest "foo, foo" (fromFoldable ["foo", "foo"]) $ testTokenParser.commaSep1 $ string "foo"
+
+    -- parse comma sep1 with newline
+    parseTest "foo, \nfoo" (fromFoldable ["foo", "foo"]) $ testTokenParser.commaSep1 $ string "foo"
+
+    -- no parse on empty string
+    parseErrorTestPosition (testTokenParser.commaSep1 $ string "foo") "" $ mkPos 1
+
+main :: forall eff . Eff (console :: CONSOLE, assert :: ASSERT |eff) Unit
 main = do
 
   parseErrorTestPosition
@@ -121,11 +422,43 @@ main = do
 
   parseTest (toList [A, B]) A (when tokpos isA)
 
-  parseTest (toList [A]) A (match tokpos A) 
-  parseTest (toList [B]) B (match tokpos B) 
-  parseTest (toList [A, B]) A (match tokpos A) 
+  parseTest (toList [A]) A (match tokpos A)
+  parseTest (toList [B]) B (match tokpos B)
+  parseTest (toList [A, B]) A (match tokpos A)
 
   parseErrorTestPosition (string "abc") "bcd" (Position { column: 1, line: 1 })
   parseErrorTestPosition (string "abc" *> eof) "abcdefg" (Position { column: 4, line: 1 })
   parseErrorTestPosition (string "a\nb\nc\n" *> eof) "a\nb\nc\nd\n" (Position { column: 1, line: 4 })
   parseErrorTestPosition (string "\ta" *> eof) "\tab" (Position { column: 10, line: 1 })
+
+  tokenParserIdentifierTest
+  tokenParserReservedTest
+  tokenParserOperatorTest
+  tokenParserReservedOpTest
+
+  tokenParserCharLiteralTest
+  tokenParserStringLiteralTest
+  tokenParserNaturalTest
+  tokenParserIntegerTest
+  tokenParserFloatTest
+  tokenParserNaturalOrFloatTest
+  tokenParserDecimalTest
+  tokenParserHexadecimalTest
+  tokenParserOctalTest
+
+  tokenParserSymbolTest
+  tokenParserLexemeTest
+  tokenParserWhiteSpaceTest
+
+  tokenParserParensTest
+  tokenParserBracesTest
+  tokenParserAnglesTest
+  tokenParserBracketsTest
+  tokenParserSemiTest
+  tokenParserCommaTest
+  tokenParserColonTest
+  tokenParserDotTest
+  tokenParserSemiSepTest
+  tokenParserSemiSep1Test
+  tokenParserCommaSepTest
+  tokenParserCommaSep1Test


### PR DESCRIPTION
This commit adds the `Text.Parsing.Parser.Language` and
`Text.Parsing.Parser.Token` modules.  This is a straight port of modules
of the same name in Haskell's `parsec` library.

  - [`Text.Parsec.Language`](https://hackage.haskell.org/package/parsec-3.1.9/docs/Text-Parsec-Language.html)
  - [`Text.Parsec.Token`](https://hackage.haskell.org/package/parsec-3.1.9/docs/Text-Parsec-Token.html)

This commit also adds the `(<??>)` combinator, which acts like a flipped
`(<?>)`.  It is convenient to use with monadic parsers:

```purescript
foo :: Parser String Unit
foo = "some message" <??> do
    string "foo"
    bar
    pure unit
```