### PR TITLE
Eq instance for ParseError

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
-sudo: false
+dist: trusty
+sudo: required
 node_js:
   - 0.10
 env:

--- a/src/Text/Parsing/Parser.purs
+++ b/src/Text/Parsing/Parser.purs
@@ -25,6 +25,9 @@ data ParseError = ParseError
 instance showParseError :: Show ParseError where
   show (ParseError msg) = "ParseError { message: " ++ msg.message ++ ", position: " ++ show msg.position ++ " }"
 
+instance eqParseError :: Eq ParseError where
+  eq (ParseError {message : m1, position : p1}) (ParseError {message : m2, position : p2}) = m1 == m2 && p1 == p2
+
 -- | `PState` contains the remaining input and current position.
 data PState s = PState
   { input :: s


### PR DESCRIPTION
It can be useful to compare `ParseError`s for equality, especially when testing parsers. This simply adds and `Eq` instance for `ParseError`