### PR TITLE
Export ParseError constructor

### DIFF
--- a/src/Text/Parsing/Parser.purs
+++ b/src/Text/Parsing/Parser.purs
@@ -1,5 +1,5 @@
 module Text.Parsing.Parser
-  ( ParseError
+  ( ParseError(..)
   , parseErrorMessage
   , parseErrorPosition
   , ParseState(..)


### PR DESCRIPTION
This used to be exported - is there any reason not to now?