### PR TITLE
Fix Show instance for ParseError

### DIFF
--- a/src/Text/Parsing/Parser.purs
+++ b/src/Text/Parsing/Parser.purs
@@ -37,7 +37,7 @@ parseErrorPosition (ParseError _ pos) = pos
 
 instance showParseError :: Show ParseError where
   show (ParseError msg pos) =
-    "(ParseError " <> show msg <> show pos <> ")"
+    "(ParseError " <> show msg <> " " <> show pos <> ")"
 
 derive instance eqParseError :: Eq ParseError
 derive instance ordParseError :: Ord ParseError

--- a/src/Text/Parsing/Parser/Pos.purs
+++ b/src/Text/Parsing/Parser/Pos.purs
@@ -16,7 +16,7 @@ newtype Position = Position
 
 instance showPosition :: Show Position where
   show (Position { line: line, column: column }) =
-    "Position { line: " <> show line <> ", column: " <> show column <> " }"
+    "(Position { line: " <> show line <> ", column: " <> show column <> " })"
 
 derive instance eqPosition :: Eq Position
 derive instance ordPosition :: Ord Position


### PR DESCRIPTION
Before:
(Left (ParseError "Expecting octave mark"Position { line: 1, column: 1 }))

After:
(Left (ParseError "Expecting octave mark" (Position { line: 1, column: 1 })))