### PR TITLE
Add a note to the docs about stack safety and using Data.List.(manyRec|someRec).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@
 !/.jshintrc
 !/.travis.yml
 /bower_components/
+/generated-docs/
 /node_modules/
 /output/

--- a/src/Text/Parsing/Parser/Combinators.purs
+++ b/src/Text/Parsing/Parser/Combinators.purs
@@ -17,6 +17,9 @@
 -- | ```purescript
 -- | Text.Parsec.many  (char 'x') <=> fromCharArray <$> Data.Array.many (char 'x')
 -- | ```
+-- |
+-- | Note that `Data.(Array|List).(many|some)` are not stack safe. If you need to parse
+-- | large numbers of items then consider using `Data.List.(manyRec|someRec)` instead.
 
 module Text.Parsing.Parser.Combinators where
 


### PR DESCRIPTION
I was bitten by this problem and had the docs mentioned it I would have avoided it.