### PR TITLE
`Compactable`and `Filterable` instances

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "purescript-arrays": "^5.0.0",
     "purescript-either": "^4.0.0",
+    "purescript-filterable": "^3.0.2",
     "purescript-foldable-traversable": "^4.0.0",
     "purescript-identity": "^4.0.0",
     "purescript-integers": "^4.0.0",

--- a/psc-package.json
+++ b/psc-package.json
@@ -1,10 +1,11 @@
 {
   "name": "purescript-parsing",
-  "set": "psc-0.12.0",
+  "set": "psc-0.13.5",
   "source": "https://github.com/purescript/package-sets.git",
   "depends": [
     "arrays",
     "either",
+    "filterable",
     "foldable-traversable",
     "identity",
     "integers",

--- a/src/Text/Parsing/Parser.purs
+++ b/src/Text/Parsing/Parser.purs
@@ -193,6 +193,7 @@ setConsumed bool = modify_ \(ParseState input pos _) ->
 consume :: forall s m. Monad m => ParserT s m Unit
 consume = setConsumed true
 
+-- | Unset the consumed flag.
 unconsume :: forall s m. Monad m => ParserT s m Unit
 unconsume = setConsumed false
 

--- a/src/Text/Parsing/Parser.purs
+++ b/src/Text/Parsing/Parser.purs
@@ -133,43 +133,43 @@ instance compactableParserT :: Monad m => Compactable (ParserT s m) where
       Nothing -> put state *> fail "Parse returned Nothing"
   separate p1 =
     { left: do
-      state <- get
-      p1 >>= case _ of
-        Left r -> pure r
-        Right r -> put state *> fail "Parse returned Right"
+        state <- get
+        p1 >>= case _ of
+          Left r -> pure r
+          Right r -> put state *> fail "Parse returned Right"
     , right: do
-      state <- get
-      p1 >>= case _ of
-        Left r -> put state *> fail "Parse returned Left"
-        Right r -> pure r
+        state <- get
+        p1 >>= case _ of
+          Left r -> put state *> fail "Parse returned Left"
+          Right r -> pure r
     }
 
 instance filterableParserT :: Monad m => Filterable (ParserT s m) where
   partitionMap pred p1 =
     { left: do
-      state <- get
-      p1 <#> pred >>= case _ of
-        Left r -> pure r
-        Right r -> put state *> fail "Predicate returned Right"
+        state <- get
+        p1 <#> pred >>= case _ of
+          Left r -> pure r
+          Right r -> put state *> fail "Predicate returned Right"
     , right: do
-      state <- get
-      p1 <#> pred >>= case _ of
-        Left r -> put state *> fail "Predicate returned Left"
-        Right r -> pure r
+        state <- get
+        p1 <#> pred >>= case _ of
+          Left r -> put state *> fail "Predicate returned Left"
+          Right r -> pure r
     }
   partition pred p1 =
     { yes: do
-      state <- get
-      r <- p1
-      case pred r of
-        true -> pure r
-        false -> put state *> fail "Result did not satisfy predicate"
+        state <- get
+        r <- p1
+        case pred r of
+          true -> pure r
+          false -> put state *> fail "Result did not satisfy predicate"
     , no: do
-      state <- get
-      r <- p1
-      case pred r of
-        true -> put state *> fail "Result unexpectedly satisfied predicate"
-        false -> pure r
+        state <- get
+        r <- p1
+        case pred r of
+          true -> put state *> fail "Result unexpectedly satisfied predicate"
+          false -> pure r
     }
   filterMap pred p1 = do
     state <- get

--- a/src/Text/Parsing/Parser.purs
+++ b/src/Text/Parsing/Parser.purs
@@ -11,6 +11,7 @@ module Text.Parsing.Parser
   , mapParserT
   , setConsumed
   , consume
+  , unconsume
   , position
   , fail
   , failWithPosition
@@ -191,6 +192,9 @@ setConsumed bool = modify_ \(ParseState input pos _) ->
 -- | Set the consumed flag.
 consume :: forall s m. Monad m => ParserT s m Unit
 consume = setConsumed true
+
+unconsume :: forall s m. Monad m => ParserT s m Unit
+unconsume = setConsumed false
 
 -- | Returns the current position in the stream.
 position :: forall s m. Monad m => ParserT s m Position

--- a/src/Text/Parsing/Parser.purs
+++ b/src/Text/Parsing/Parser.purs
@@ -136,11 +136,11 @@ instance compactableParserT :: Monad m => Compactable (ParserT s m) where
         state <- get
         p1 >>= case _ of
           Left r -> pure r
-          Right r -> put state *> fail "Parse returned Right"
+          Right _ -> put state *> fail "Parse returned Right"
     , right: do
         state <- get
         p1 >>= case _ of
-          Left r -> put state *> fail "Parse returned Left"
+          Left _ -> put state *> fail "Parse returned Left"
           Right r -> pure r
     }
 
@@ -150,11 +150,11 @@ instance filterableParserT :: Monad m => Filterable (ParserT s m) where
         state <- get
         p1 <#> pred >>= case _ of
           Left r -> pure r
-          Right r -> put state *> fail "Predicate returned Right"
+          Right _ -> put state *> fail "Predicate returned Right"
     , right: do
         state <- get
         p1 <#> pred >>= case _ of
-          Left r -> put state *> fail "Predicate returned Left"
+          Left _ -> put state *> fail "Predicate returned Left"
           Right r -> pure r
     }
   partition pred p1 =

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -15,7 +15,7 @@ import Effect (Effect)
 import Effect.Console (logShow)
 import Test.Assert (assert')
 import Text.Parsing.Parser (Parser, ParserT, runParser, parseErrorPosition)
-import Text.Parsing.Parser.Combinators (endBy1, sepBy1, sepBy, optionMaybe, try, chainl, between)
+import Text.Parsing.Parser.Combinators (endBy1, sepBy1, sepBy, optionMaybe, try, chainl, between, filterMapWithError, filterMapEither)
 import Text.Parsing.Parser.Expr (Assoc(..), Operator(..), buildExprParser)
 import Text.Parsing.Parser.Language (javaStyle, haskellStyle, haskellDef)
 import Text.Parsing.Parser.Pos (Position(..), initialPos)
@@ -446,6 +446,20 @@ filterableTest = do
   -- when run after another parser with *>, correct error position is given
   (\p -> parseErrorTestPosition p "12" (mkPos 2))
     $ digit *> (_.yes <<< partition (_ == 3)) digit
+
+  -- filterMapWithError using Just as the mapper will act just like the original parser
+  parseTest "6" 6
+    $ filterMapWithError Just "shouldn't fail" digit
+
+  -- filterMapEither using Right as the mapper will act just like the original parser
+  parseTest "6" 6
+    $ filterMapEither Right digit
+
+  -- when run after another parser with *>, correct error position is given
+  (\p -> parseErrorTestPosition p "12" (mkPos 2))
+    $ digit *> filterMapEither
+                 (\n -> if n == 2 then Left "error" else Right n)
+                 digit
 
 main :: Effect Unit
 main = do

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -6,7 +6,8 @@ import Control.Alt ((<|>))
 import Control.Lazy (fix)
 import Data.Array (some)
 import Data.Either (Either(..))
-import Data.List (List(..), fromFoldable, many)
+import Data.Filterable (filter, filterMap, compact, separate, partition, partitionMap)
+import Data.List (List(..), fromFoldable, many, tail, (:))
 import Data.Maybe (Maybe(..))
 import Data.String.CodeUnits (fromCharArray, singleton)
 import Data.Tuple (Tuple(..))
@@ -14,7 +15,7 @@ import Effect (Effect)
 import Effect.Console (logShow)
 import Test.Assert (assert')
 import Text.Parsing.Parser (Parser, ParserT, runParser, parseErrorPosition)
-import Text.Parsing.Parser.Combinators (endBy1, sepBy1, optionMaybe, try, chainl, between)
+import Text.Parsing.Parser.Combinators (endBy1, sepBy1, sepBy, optionMaybe, try, chainl, between)
 import Text.Parsing.Parser.Expr (Assoc(..), Operator(..), buildExprParser)
 import Text.Parsing.Parser.Language (javaStyle, haskellStyle, haskellDef)
 import Text.Parsing.Parser.Pos (Position(..), initialPos)
@@ -412,6 +413,40 @@ javaStyleTest = do
         "hello {- comment\n -} foo"
         (mkPos 7)
 
+filterableTest :: TestM
+filterableTest = do
+  -- filter does nothing when the predicate returns true
+  parseTest "6" 6 (filter (_ /= 5) digit)
+
+  -- filter acts as if the parser failed when predicate returns false
+  parseErrorTestPosition (filter (_ /= 6) digit) "6" (mkPos 1)
+
+  -- if a result is "filtered away", `alt` will try the next parser
+  parseTest "6" 6
+    $ filter (_ /= 6) digit <|> filter (_ /= 7) digit
+
+  -- using filterMap to elegantly apply a function that returns maybe
+  parseTest "1,2,3,4" (2 : 3 : 4 : Nil)
+    $ filterMap tail (digit `sepBy` string ",")
+
+-- `filterMap f` should be the same as `compact <<< map f`
+  parseTest "1,2,3,4" (2 : 3 : 4 : Nil)
+    $ (compact <<< map tail) (digit `sepBy` string ",")
+
+  -- same as above, throwing an error in the parser if the filterMap fails
+  (\p -> parseErrorTestPosition p "" (mkPos 1))
+    $ filterMap tail (digit `sepBy` string ",")
+
+  parseTest "1" 2
+    $ (_.right <<< separate) (digit $> Right 2)
+
+  parseTest "1" 3
+    $ (_.left <<< partitionMap (\n -> Left $ n + 2)) digit
+
+  -- when run after another parser with *>, correct error position is given
+  (\p -> parseErrorTestPosition p "12" (mkPos 2))
+    $ digit *> (_.yes <<< partition (_ == 3)) digit
+
 main :: Effect Unit
 main = do
 
@@ -493,3 +528,5 @@ main = do
 
   haskellStyleTest
   javaStyleTest
+
+  filterableTest


### PR DESCRIPTION
Fixes #84 
### What does this pull request do?

Implements `Compactable`and `Filterable` instances for `ParserT` 

## Where should the reviewer start?

instance implementations in src/Text/Parsing/Parser.purs

## How should this be manually tested?

Tests provided in test/Main.purs

## Other Notes:

Maybe we could add an example showing how to use `filterMap` to apply functions with type `a -> Maybe a` to the result of a parser "for free"
