### PR TITLE
Revert broken combinators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Breaking changes:
 New features:
 
 Bugfixes:
+- Revert combinator implementation changes from #102 (@robertdp, https://github.com/purescript-contrib/purescript-parsing/pull/116)
 
 Other improvements:
 


### PR DESCRIPTION
**Description of the change**

This reverts the changes in PR #102 which accidentally broke several combinators. It now follows the same approach as `string-parsers`

This should resolve #113 and replace PR #114

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
