### PR TITLE
CodePoint versions of oneOf and noneOf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Breaking changes:
 
 New features:
 
+- Added primitive parsers `oneOfCodePoints` and `noneOfCodePoints` - `CodePoint`
+  versions of `oneOf` and `noneOf` respectively. (#127 by @fsoikin)
+
 Bugfixes:
 
 Other improvements:

--- a/src/Text/Parsing/Parser/String.purs
+++ b/src/Text/Parsing/Parser/String.purs
@@ -33,13 +33,15 @@ module Text.Parsing.Parser.String
 
 import Prelude hiding (between)
 
+import Control.Alt ((<|>))
+import Control.Lazy (defer)
 import Control.Monad.State (get, put)
 import Data.Array (notElem)
 import Data.Char (fromCharCode)
 import Data.CodePoint.Unicode (isSpace)
 import Data.Foldable (elem)
 import Data.Maybe (Maybe(..))
-import Data.String (CodePoint, Pattern(..), null, stripPrefix, uncons)
+import Data.String (CodePoint, Pattern(..), null, singleton, stripPrefix, uncons)
 import Data.String.CodeUnits as SCU
 import Data.Tuple (Tuple(..), fst)
 import Text.Parsing.Parser (ParseState(..), ParserT, fail)
@@ -125,11 +127,11 @@ noneOf ss = satisfy (flip notElem ss) <?> ("none of " <> show ss)
 
 -- | Match one of the Unicode characters in the array.
 oneOfCodePoints :: forall m. Monad m => Array CodePoint -> ParserT String m CodePoint
-oneOfCodePoints ss = satisfyCodePoint (flip elem ss) <?> ("one of " <> show ss)
+oneOfCodePoints ss = satisfyCodePoint (flip elem ss) <|> defer \_ -> fail ("Expected one of " <> show (singleton <$> ss))
 
 -- | Match any Unicode character not in the array.
 noneOfCodePoints :: forall m. Monad m => Array CodePoint -> ParserT String m CodePoint
-noneOfCodePoints ss = satisfyCodePoint (flip notElem ss) <?> ("none of " <> show ss)
+noneOfCodePoints ss = satisfyCodePoint (flip notElem ss) <|> defer \_ -> fail ("Expected none of " <> show (singleton <$> ss))
 
 -- | Updates a `Position` by adding the columns and lines in `String`.
 updatePosString :: Position -> String -> Position

--- a/src/Text/Parsing/Parser/String.purs
+++ b/src/Text/Parsing/Parser/String.purs
@@ -127,11 +127,11 @@ noneOf ss = satisfy (flip notElem ss) <?> ("none of " <> show ss)
 
 -- | Match one of the Unicode characters in the array.
 oneOfCodePoints :: forall m. Monad m => Array CodePoint -> ParserT String m CodePoint
-oneOfCodePoints ss = satisfyCodePoint (flip elem ss) <|> defer \_ -> fail ("Expected one of " <> show (singleton <$> ss))
+oneOfCodePoints ss = satisfyCodePoint (flip elem ss) <|> defer \_ -> fail $ "Expected one of " <> show (singleton <$> ss)
 
 -- | Match any Unicode character not in the array.
 noneOfCodePoints :: forall m. Monad m => Array CodePoint -> ParserT String m CodePoint
-noneOfCodePoints ss = satisfyCodePoint (flip notElem ss) <|> defer \_ -> fail ("Expected none of " <> show (singleton <$> ss))
+noneOfCodePoints ss = satisfyCodePoint (flip notElem ss) <|> defer \_ -> fail $ "Expected none of " <> show (singleton <$> ss)
 
 -- | Updates a `Position` by adding the columns and lines in `String`.
 updatePosString :: Position -> String -> Position

--- a/src/Text/Parsing/Parser/String.purs
+++ b/src/Text/Parsing/Parser/String.purs
@@ -25,7 +25,9 @@ module Text.Parsing.Parser.String
   , whiteSpace
   , skipSpaces
   , oneOf
+  , oneOfCodePoints
   , noneOf
+  , noneOfCodePoints
   , match
   ) where
 
@@ -120,6 +122,14 @@ oneOf ss = satisfy (flip elem ss) <?> ("one of " <> show ss)
 -- | Match any BMP `Char` not in the array.
 noneOf :: forall m. Monad m => Array Char -> ParserT String m Char
 noneOf ss = satisfy (flip notElem ss) <?> ("none of " <> show ss)
+
+-- | Match one of the Unicode characters in the array.
+oneOfCodePoints :: forall m. Monad m => Array CodePoint -> ParserT String m CodePoint
+oneOfCodePoints ss = satisfyCodePoint (flip elem ss) <?> ("one of " <> show ss)
+
+-- | Match any Unicode character not in the array.
+noneOfCodePoints :: forall m. Monad m => Array CodePoint -> ParserT String m CodePoint
+noneOfCodePoints ss = satisfyCodePoint (flip notElem ss) <?> ("none of " <> show ss)
 
 -- | Updates a `Position` by adding the columns and lines in `String`.
 updatePosString :: Position -> String -> Position

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -5,6 +5,7 @@ import Prelude hiding (between, when)
 import Control.Alt ((<|>))
 import Control.Lazy (fix)
 import Data.Array (some)
+import Data.Array as Array
 import Data.Either (Either(..))
 import Data.List (List(..), fromFoldable, many)
 import Data.List.NonEmpty (cons, cons')
@@ -21,7 +22,7 @@ import Text.Parsing.Parser.Combinators (between, chainl, endBy1, optionMaybe, se
 import Text.Parsing.Parser.Expr (Assoc(..), Operator(..), buildExprParser)
 import Text.Parsing.Parser.Language (haskellDef, haskellStyle, javaStyle)
 import Text.Parsing.Parser.Pos (Position(..), initialPos)
-import Text.Parsing.Parser.String (anyChar, anyCodePoint, char, eof, satisfy, string, whiteSpace)
+import Text.Parsing.Parser.String (anyChar, anyCodePoint, char, eof, noneOfCodePoints, oneOfCodePoints, satisfy, string, whiteSpace)
 import Text.Parsing.Parser.Token (TokenParser, letter, makeTokenParser, match, token, when)
 
 parens :: forall m a. Monad m => ParserT String m a -> ParserT String m a
@@ -464,6 +465,11 @@ main = do
     letterx <- string "𝅘𝅥𝅯" <|> string "x"
     sixteenth <- string "𝅘𝅥𝅯" <|> (singleton <$> char 'x')
     pure $ [ SCP.singleton quarter, eighth, letterx, sixteenth ]
+
+  parseTest "🤔💯✅🤔💯" [ "🤔💯", "✅🤔💯" ] do
+    none <- Array.many $ noneOfCodePoints $ SCP.toCodePointArray "❓✅"
+    one <- Array.many $ oneOfCodePoints $ SCP.toCodePointArray "🤔💯✅"
+    pure $ SCP.fromCodePointArray <$> [ none, one ]
 
   parseTest "aa  bb" [ "aa", "  ", "bb" ] do
     aa <- SCU.fromCharArray <$> some letter


### PR DESCRIPTION
**Description of the change**

* In https://github.com/purescript-contrib/purescript-parsing/pull/119 the `anyChar` primitive was modified such that it no longer always succeeds, but succeeds only on BMP characters, and a new `anyCodePoint` was added with the former semantics of `anyChar`. A corresponding version of `satisfy`, - `satisfyCodePoint`, - was added as well.
* This PR goes a bit further in the same direction, adding `CodePoint` versions of `oneOf` and `noneOf` - `oneOfCodePoints` and `noneOfCodePoints` respectively.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] ~Linked any existing issues or proposals that this pull request should close~
- [x] ~Updated or added relevant documentation in the README and/or documentation directory~
- [x] Added a test for the contribution (if applicable)
