### PR TITLE
Lazy error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ New features:
 
 - Added a new operator `<~?>` (alias of `withLazyErrorMessage`), an analog of
   `<?>`, but allows the error message to be deferred until there is actually an
-  error. Handy when the error message is expensive to construct. (#128 by @fsoikin)
+  error. Handy when the error message is expensive to construct. (#129 by @fsoikin)
 
 ## [v7.1.0](https://github.com/purescript-contrib/purescript-parsing/releases/tag/v7.1.0) - 2022-01-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Notable changes to this project are documented in this file. The format is based
 
 ## [Unreleased]
 
+New features:
+
+- Added a new operator `<~?>` (alias of `withLazyErrorMessage`), an analog of
+  `<?>`, but allows the error message to be deferred until there is actually an
+  error. Handy when the error message is expensive to construct. (#128 by @fsoikin)
+
 ## [v7.1.0](https://github.com/purescript-contrib/purescript-parsing/releases/tag/v7.1.0) - 2022-01-06
 
 Breaking changes:

--- a/src/Text/Parsing/Parser/Combinators.purs
+++ b/src/Text/Parsing/Parser/Combinators.purs
@@ -50,7 +50,7 @@ infixl 3 withErrorMessage as <?>
 -- |
 -- |```purs
 -- |parseBang :: Parser Char
--- |parseBang = char '!' <??> \_ -> "Expected a bang"
+-- |parseBang = char '!' <~?> \_ -> "Expected a bang"
 -- |```
 withLazyErrorMessage :: forall m s a. Monad m => ParserT s m a -> (Unit -> String) -> ParserT s m a
 withLazyErrorMessage p msg = p <|> defer \_ -> fail ("Expected " <> msg unit)

--- a/src/Text/Parsing/Parser/Combinators.purs
+++ b/src/Text/Parsing/Parser/Combinators.purs
@@ -40,7 +40,7 @@ import Text.Parsing.Parser (ParseError(..), ParseState(..), ParserT(..), fail)
 
 -- | Provide an error message in the case of failure.
 withErrorMessage :: forall m s a. Monad m => ParserT s m a -> String -> ParserT s m a
-withErrorMessage p msg = withLazyErrorMessage p $ const msg
+withErrorMessage p msg = p <|> fail ("Expected " <> msg unit)
 
 infixl 3 withErrorMessage as <?>
 

--- a/src/Text/Parsing/Parser/Combinators.purs
+++ b/src/Text/Parsing/Parser/Combinators.purs
@@ -40,7 +40,7 @@ import Text.Parsing.Parser (ParseError(..), ParseState(..), ParserT(..), fail)
 
 -- | Provide an error message in the case of failure.
 withErrorMessage :: forall m s a. Monad m => ParserT s m a -> String -> ParserT s m a
-withErrorMessage p msg = p <|> fail ("Expected " <> msg unit)
+withErrorMessage p msg = p <|> fail ("Expected " <> msg)
 
 infixl 3 withErrorMessage as <?>
 

--- a/src/Text/Parsing/Parser/String.purs
+++ b/src/Text/Parsing/Parser/String.purs
@@ -33,8 +33,6 @@ module Text.Parsing.Parser.String
 
 import Prelude hiding (between)
 
-import Control.Alt ((<|>))
-import Control.Lazy (defer)
 import Control.Monad.State (get, put)
 import Data.Array (notElem)
 import Data.Char (fromCharCode)
@@ -45,7 +43,7 @@ import Data.String (CodePoint, Pattern(..), null, singleton, stripPrefix, uncons
 import Data.String.CodeUnits as SCU
 import Data.Tuple (Tuple(..), fst)
 import Text.Parsing.Parser (ParseState(..), ParserT, fail)
-import Text.Parsing.Parser.Combinators (skipMany, tryRethrow, (<?>))
+import Text.Parsing.Parser.Combinators (skipMany, tryRethrow, (<?>), (<~?>))
 import Text.Parsing.Parser.Pos (Position(..))
 import Unsafe.Coerce (unsafeCoerce)
 
@@ -119,19 +117,19 @@ skipSpaces = skipMany (satisfyCodePoint isSpace)
 
 -- | Match one of the BMP `Char`s in the array.
 oneOf :: forall m. Monad m => Array Char -> ParserT String m Char
-oneOf ss = satisfy (flip elem ss) <?> ("one of " <> show ss)
+oneOf ss = satisfy (flip elem ss) <~?> \_ -> "one of " <> show ss
 
 -- | Match any BMP `Char` not in the array.
 noneOf :: forall m. Monad m => Array Char -> ParserT String m Char
-noneOf ss = satisfy (flip notElem ss) <?> ("none of " <> show ss)
+noneOf ss = satisfy (flip notElem ss) <~?> \_ -> "none of " <> show ss
 
 -- | Match one of the Unicode characters in the array.
 oneOfCodePoints :: forall m. Monad m => Array CodePoint -> ParserT String m CodePoint
-oneOfCodePoints ss = satisfyCodePoint (flip elem ss) <|> defer \_ -> fail $ "Expected one of " <> show (singleton <$> ss)
+oneOfCodePoints ss = satisfyCodePoint (flip elem ss) <~?> \_ -> "one of " <> show (singleton <$> ss)
 
 -- | Match any Unicode character not in the array.
 noneOfCodePoints :: forall m. Monad m => Array CodePoint -> ParserT String m CodePoint
-noneOfCodePoints ss = satisfyCodePoint (flip notElem ss) <|> defer \_ -> fail $ "Expected none of " <> show (singleton <$> ss)
+noneOfCodePoints ss = satisfyCodePoint (flip notElem ss) <~?> \_ -> "none of " <> show (singleton <$> ss)
 
 -- | Updates a `Position` by adding the columns and lines in `String`.
 updatePosString :: Position -> String -> Position


### PR DESCRIPTION
**Description of the change**

fixes #128 

* Added a new operator `<~?>`, which is like `<?>`, but takes a deferred message - i.e. `Unit -> String`.
* This is handy when the error message is expensive-ish to construct.
* Made use of this in `oneOf`, `noneOf`, `oneOfCodePoints`, and `noneOfCodePoints`.
* In all other usages of `<?>` the error message is either a string literal or a very mall expression, like `show c` (where `c :: Char`), which means that in all those cases constructing a closure for deferred message would be more expensive. So I left all those usages alone.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] ~Updated or added relevant documentation in the README and/or documentation directory~
- [x] ~Added a test for the contribution (if applicable)~
