### PR TITLE
Some stack-safe sequence combinators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Notable changes to this project are documented in this file. The format is based
 New features:
 
 - Added stack-safe (at the expense of `MonadRec` constraint) combinators
-  `manyTillRec`, `many1TillRec`, `sepEndByRec`, and `sepEndBy1Rec`.
+  `manyTillRec`, `many1TillRec`, `sepEndByRec`, and `sepEndBy1Rec`. (#130 by @fsoikin)
 
 ## [v7.1.0](https://github.com/purescript-contrib/purescript-parsing/releases/tag/v7.1.0) - 2022-01-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Notable changes to this project are documented in this file. The format is based
 
 ## [Unreleased]
 
+New features:
+
+- Added stack-safe (at the expense of `MonadRec` constraint) combinators
+  `manyTillRec`, `many1TillRec`, `sepEndByRec`, and `sepEndBy1Rec`.
+
 ## [v7.1.0](https://github.com/purescript-contrib/purescript-parsing/releases/tag/v7.1.0) - 2022-01-06
 
 Breaking changes:

--- a/src/Text/Parsing/Parser/Combinators.purs
+++ b/src/Text/Parsing/Parser/Combinators.purs
@@ -140,16 +140,16 @@ sepEndBy1Rec p sep = do
   a <- p
   (NEL.cons' a <$> tailRecM go Nil) <|> pure (NEL.singleton a)
   where
-    go :: List a -> ParserT s m (Step (List a) (List a))
-    go acc = nextOne <|> done
-      where
-        nextOne = do
-          -- First make sure there's a separator.
-          _ <- sep
-          -- Then try the phrase and loop if it's there, or bail if it's not there.
-          (p <#> \a -> Loop $ a : acc) <|> done
+  go :: List a -> ParserT s m (Step (List a) (List a))
+  go acc = nextOne <|> done
+    where
+    nextOne = do
+      -- First make sure there's a separator.
+      _ <- sep
+      -- Then try the phrase and loop if it's there, or bail if it's not there.
+      (p <#> \a -> Loop $ a : acc) <|> done
 
-        done = defer \_ -> pure $ Done $ reverse acc
+    done = defer \_ -> pure $ Done $ reverse acc
 
 -- | Parse phrases delimited and terminated by a separator, requiring at least one match.
 endBy1 :: forall m s a sep. Monad m => ParserT s m a -> ParserT s m sep -> ParserT s m (NonEmptyList a)
@@ -233,9 +233,9 @@ manyTill p end = scan
 manyTillRec :: forall s a m e. MonadRec m => ParserT s m a -> ParserT s m e -> ParserT s m (List a)
 manyTillRec p end = tailRecM go Nil
   where
-    go :: List a -> ParserT s m (Step (List a) (List a))
-    go acc =
-      (end <#> \_ -> Done $ reverse acc)
+  go :: List a -> ParserT s m (Step (List a) (List a))
+  go acc =
+    (end <#> \_ -> Done $ reverse acc)
       <|> (p <#> \x -> Loop $ x : acc)
 
 -- | Parse several phrases until the specified terminator matches, requiring at least one match.

--- a/src/Text/Parsing/Parser/Combinators.purs
+++ b/src/Text/Parsing/Parser/Combinators.purs
@@ -24,12 +24,14 @@ module Text.Parsing.Parser.Combinators where
 
 import Prelude
 
+import Control.Lazy (defer)
 import Control.Monad.Except (ExceptT(..), runExceptT)
+import Control.Monad.Rec.Class (class MonadRec, Step(..), tailRecM)
 import Control.Monad.State (StateT(..), runStateT)
 import Control.Plus (empty, (<|>))
 import Data.Either (Either(..))
 import Data.Foldable (class Foldable, foldl)
-import Data.List (List(..), many, (:))
+import Data.List (List(..), many, reverse, (:))
 import Data.List.NonEmpty (NonEmptyList)
 import Data.List.NonEmpty as NEL
 import Data.Maybe (Maybe(..))
@@ -118,6 +120,10 @@ sepBy1 p sep = do
 sepEndBy :: forall m s a sep. Monad m => ParserT s m a -> ParserT s m sep -> ParserT s m (List a)
 sepEndBy p sep = map NEL.toList (sepEndBy1 p sep) <|> pure Nil
 
+-- | Stack-safe version of `sepEndBy` at the expense of `MonadRec` constraint
+sepEndByRec :: forall m s a sep. MonadRec m => ParserT s m a -> ParserT s m sep -> ParserT s m (List a)
+sepEndByRec p sep = map NEL.toList (sepEndBy1Rec p sep) <|> pure Nil
+
 -- | Parse phrases delimited and optionally terminated by a separator, requiring at least one match.
 sepEndBy1 :: forall m s a sep. Monad m => ParserT s m a -> ParserT s m sep -> ParserT s m (NonEmptyList a)
 sepEndBy1 p sep = do
@@ -127,6 +133,23 @@ sepEndBy1 p sep = do
       as <- sepEndBy p sep
       pure (NEL.cons' a as)
   ) <|> pure (NEL.singleton a)
+
+-- | Stack-safe version of `sepEndBy1` at the expense of `MonadRec` constraint
+sepEndBy1Rec :: forall m s a sep. MonadRec m => ParserT s m a -> ParserT s m sep -> ParserT s m (NonEmptyList a)
+sepEndBy1Rec p sep = do
+  a <- p
+  (NEL.cons' a <$> tailRecM go Nil) <|> pure (NEL.singleton a)
+  where
+    go :: List a -> ParserT s m (Step (List a) (List a))
+    go acc = nextOne <|> done
+      where
+        nextOne = do
+          -- First make sure there's a separator.
+          _ <- sep
+          -- Then try the phrase and loop if it's there, or bail if it's not there.
+          (p <#> \a -> Loop $ a : acc) <|> done
+
+        done = defer \_ -> pure $ Done $ reverse acc
 
 -- | Parse phrases delimited and terminated by a separator, requiring at least one match.
 endBy1 :: forall m s a sep. Monad m => ParserT s m a -> ParserT s m sep -> ParserT s m (NonEmptyList a)
@@ -206,9 +229,22 @@ manyTill p end = scan
     xs <- scan
     pure (x : xs)
 
+-- | Stack-safe version of `manyTill` at the expense of `MonadRec` constraint
+manyTillRec :: forall s a m e. MonadRec m => ParserT s m a -> ParserT s m e -> ParserT s m (List a)
+manyTillRec p end = tailRecM go Nil
+  where
+    go :: List a -> ParserT s m (Step (List a) (List a))
+    go acc =
+      (end <#> \_ -> Done $ reverse acc)
+      <|> (p <#> \x -> Loop $ x : acc)
+
 -- | Parse several phrases until the specified terminator matches, requiring at least one match.
 many1Till :: forall s a m e. Monad m => ParserT s m a -> ParserT s m e -> ParserT s m (NonEmptyList a)
 many1Till p end = do
   x <- p
   xs <- manyTill p end
   pure (NEL.cons' x xs)
+
+-- | Stack-safe version of `many1Till` at the expense of `MonadRec` constraint
+many1TillRec :: forall s a m e. MonadRec m => ParserT s m a -> ParserT s m e -> ParserT s m (NonEmptyList a)
+many1TillRec p end = NEL.cons' <$> p <*> manyTillRec p end

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -99,28 +99,28 @@ manySatisfyTest = do
 -- of clear explicit recursion.
 stackSafeLoopsTest :: TestM
 stackSafeLoopsTest = do
-  parseTest "aaabaa" (toUnfoldable ["a", "a", "a"]) $
+  parseTest "aaabaa" (toUnfoldable [ "a", "a", "a" ]) $
     manyTillRec (string "a") (string "b")
   parseTest "baa" Nil $
     manyTillRec (string "a") (string "b")
 
-  parseTest "aaabaa" (NE.cons' "a" $ toUnfoldable ["a", "a"]) $
+  parseTest "aaabaa" (NE.cons' "a" $ toUnfoldable [ "a", "a" ]) $
     many1TillRec (string "a") (string "b")
   parseErrorTestPosition
     (many1TillRec (string "a") (string "b"))
     "baa"
     (Position { line: 1, column: 1 })
 
-  parseTest "a,a,a,b,a,a" (toUnfoldable ["a", "a", "a"]) $
+  parseTest "a,a,a,b,a,a" (toUnfoldable [ "a", "a", "a" ]) $
     sepEndByRec (string "a") (string ",")
-  parseTest "a,a,abaa" (toUnfoldable ["a", "a", "a"]) $
+  parseTest "a,a,abaa" (toUnfoldable [ "a", "a", "a" ]) $
     sepEndByRec (string "a") (string ",")
   parseTest "b,a,a" Nil $
     sepEndByRec (string "a") (string ",")
 
-  parseTest "a,a,a,b,a,a" (NE.cons' "a" $ toUnfoldable ["a", "a"]) $
+  parseTest "a,a,a,b,a,a" (NE.cons' "a" $ toUnfoldable [ "a", "a" ]) $
     sepEndBy1Rec (string "a") (string ",")
-  parseTest "a,a,abaa" (NE.cons' "a" $ toUnfoldable ["a", "a"]) $
+  parseTest "a,a,abaa" (NE.cons' "a" $ toUnfoldable [ "a", "a" ]) $
     sepEndBy1Rec (string "a") (string ",")
   parseErrorTestPosition
     (sepEndBy1Rec (string "a") (string ","))


### PR DESCRIPTION
**Description of the change**

Combinators dealing with sequences, such as `many1`, `manyTill`, `sepBy`, etc. are stack-unsafe. When given a long enough input, they will overflow the stack.

`Data.List` offers similar general combinators `many` and `some`, and provides a patch for this problem in the form of stack-safe counterparts - `manyRec` and `someRec` respectively, - which are made stack-safe at the expense of an additional `MonadRec` constraint.

Following this pattern, this PR adds stack-safe counterparts for some of the parser combinators - specifically, `sepEndByRec`, `sepEndBy1Rec`, `manyTillRec`, and `many1TillRec`.

These are not _all_ the sequence combinators exported from `Text.Parsing.Parser.Combinators`, but only those that we needed for our purposes at my ~slave dungeoun~ day job. I figured I'd contribute them back to the library since it's very low effort to do so.

If the High Counsil pleases, I can take it upon myself to develop similar counterparts for the other sequence combinators.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] ~Linked any existing issues or proposals that this pull request should close~
- [x] ~Updated or added relevant documentation in the README and/or documentation directory~
- [x] Added a test for the contribution (if applicable)
