### PR TITLE
New module Text.Parsing.Parser.String.Basic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ New features:
 - `Parser.Combinators.many1Till_` (#143 by @jamesbrock)
 - `Parser.Combinators.manyTillRec_` (#143 by @jamesbrock)
 - `Parser.Combinators.many1TillRec_` (#143 by @jamesbrock)
+- `Parser.String.Basic.number` (#142 by @jamesbrock)
+- `Parser.String.Basic.intDecimal` (#142 by @jamesbrock)
 
 Bugfixes:
 
@@ -23,8 +25,11 @@ Bugfixes:
 
 Other improvements:
 
+- Moved the `Parser.Token` parsers `digit`, `hexDigit`, `octDigit`, `upper`,
+  `space`, `letter`, `alphaNum` into the new module `Parser.String.Basic`. (#142 by @jamesdbrock)
 - Documentation. (#140 by @jamesdbrock)
 - Documentation. (#143 by @jamesdbrock)
+- Documentation. (#142 by @jamesdbrock)
 
 ## [v8.1.0](https://github.com/purescript-contrib/purescript-parsing/releases/tag/v8.1.0) - 2022-01-10
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ and then the parser will succeed and return `Right true`.
 
 ### More parsers
 
-There are other `String` parsers in the module `Text.Parsing.Parser.Token`, for example the parser `letter :: Parser String Char` which will accept any single alphabetic letter.
+There are other `String` parsers in the module `Text.Parsing.Parser.String.Basic`, for example the parser `letter :: Parser String Char` which will accept any single alphabetic letter.
 
 ### Parser combinators
 

--- a/bench/Main.purs
+++ b/bench/Main.purs
@@ -55,7 +55,7 @@ import Effect.Unsafe (unsafePerformEffect)
 import Performance.Minibench (benchWith)
 import Text.Parsing.Parser (Parser, runParser)
 import Text.Parsing.Parser.String (string)
-import Text.Parsing.Parser.Token (digit)
+import Text.Parsing.Parser.String.Basic (digit)
 import Text.Parsing.StringParser as StringParser
 import Text.Parsing.StringParser.CodePoints as StringParser.CodePoints
 import Text.Parsing.StringParser.CodeUnits as StringParser.CodeUnits

--- a/spago.dhall
+++ b/spago.dhall
@@ -12,6 +12,7 @@
   , "math"
   , "maybe"
   , "newtype"
+  , "numbers"
   , "prelude"
   , "strings"
   , "tailrec"

--- a/src/Text/Parsing/Parser/Expr.purs
+++ b/src/Text/Parsing/Parser/Expr.purs
@@ -1,3 +1,7 @@
+-- | This module is a port of the Haskell
+-- | [__Text.Parsec.Expr__](https://hackage.haskell.org/package/docs/Text-Parsec-Expr.html)
+-- | module.
+
 module Text.Parsing.Parser.Expr
   ( Assoc(..)
   , Operator(..)

--- a/src/Text/Parsing/Parser/Indent.purs
+++ b/src/Text/Parsing/Parser/Indent.purs
@@ -1,5 +1,7 @@
--- | This is purescript-port of Text.Parsing.Indent
--- | <https://hackage.haskell.org/package/indents-0.3.3/docs/Text-Parsec-Indent.html>, 05.07.2016.
+-- | This module is a port of the Haskell
+-- | [__Text.Parsec.Indent__](https://hackage.haskell.org/package/indents-0.3.3/docs/Text-Parsec-Indent.html)
+-- | module from 2016-05-07.
+-- |
 -- | A module to construct indentation aware parsers. Many programming
 -- | language have indentation based syntax rules e.g. python and Haskell.
 -- | This module exports combinators to create such parsers.

--- a/src/Text/Parsing/Parser/Language.purs
+++ b/src/Text/Parsing/Parser/Language.purs
@@ -1,3 +1,6 @@
+-- | This module is a port of the Haskell
+-- | [__Text.Parsec.Language__](https://hackage.haskell.org/package/parsec/docs/Text-Parsec-Language.html)
+-- | module.
 module Text.Parsing.Parser.Language
   ( haskellDef
   , haskell
@@ -11,7 +14,8 @@ import Prelude
 import Control.Alt ((<|>))
 import Text.Parsing.Parser (ParserT)
 import Text.Parsing.Parser.String (char, oneOf)
-import Text.Parsing.Parser.Token (GenLanguageDef(..), LanguageDef, TokenParser, alphaNum, letter, makeTokenParser, unGenLanguageDef)
+import Text.Parsing.Parser.String.Basic (alphaNum, letter)
+import Text.Parsing.Parser.Token (GenLanguageDef(..), LanguageDef, TokenParser, makeTokenParser, unGenLanguageDef)
 
 -----------------------------------------------------------
 -- Styles: haskellStyle, javaStyle

--- a/src/Text/Parsing/Parser/String/Basic.purs
+++ b/src/Text/Parsing/Parser/String/Basic.purs
@@ -1,0 +1,119 @@
+-- | Basic `String` parsers derived from primitive `String` parsers.
+-- |
+-- | Note: In the future, the
+-- | __noneOf__, __noneOfCodePoints__, __oneOf__, __oneOfCodePoints__, __skipSpaces__, __whiteSpace__
+-- | should be moved into this module and removed from the
+-- | __Text.Parsing.Parser.String__ module, because they are not primitive parsers.
+module Text.Parsing.Parser.String.Basic
+  ( digit
+  , hexDigit
+  , octDigit
+  , letter
+  , space
+  , upper
+  , alphaNum
+  , intDecimal
+  , number
+  , module Text.Parsing.Parser.String
+  ) where
+
+import Prelude
+
+import Data.CodePoint.Unicode (isAlpha, isAlphaNum, isDecDigit, isHexDigit, isOctDigit, isSpace, isUpper)
+import Data.Int as Data.Int
+import Data.Maybe (Maybe(..))
+import Data.Number (infinity, nan)
+import Data.Number as Data.Number
+import Data.String (CodePoint)
+import Data.String.CodePoints (codePointFromChar)
+import Data.Tuple (Tuple(..))
+import Text.Parsing.Parser (ParserT, fail)
+import Text.Parsing.Parser.Combinators (choice, skipMany, (<?>))
+import Text.Parsing.Parser.String (noneOf, noneOfCodePoints, oneOf, oneOfCodePoints, skipSpaces, whiteSpace)
+import Text.Parsing.Parser.String as Parser.String
+
+-- | Parse a digit.  Matches any char that satisfies `Data.CodePoint.Unicode.isDecDigit`.
+digit :: forall m. Monad m => ParserT String m Char
+digit = satisfyCP isDecDigit <?> "digit"
+
+-- | Parse a hex digit.  Matches any char that satisfies `Data.CodePoint.Unicode.isHexDigit`.
+hexDigit :: forall m. Monad m => ParserT String m Char
+hexDigit = satisfyCP isHexDigit <?> "hex digit"
+
+-- | Parse an octal digit.  Matches any char that satisfies `Data.CodePoint.Unicode.isOctDigit`.
+octDigit :: forall m. Monad m => ParserT String m Char
+octDigit = satisfyCP isOctDigit <?> "oct digit"
+
+-- | Parse an uppercase letter.  Matches any char that satisfies `Data.CodePoint.Unicode.isUpper`.
+upper :: forall m. Monad m => ParserT String m Char
+upper = satisfyCP isUpper <?> "uppercase letter"
+
+-- | Parse a space character.  Matches any char that satisfies `Data.CodePoint.Unicode.isSpace`.
+space :: forall m. Monad m => ParserT String m Char
+space = satisfyCP isSpace <?> "space"
+
+-- | Parse an alphabetical character.  Matches any char that satisfies `Data.CodePoint.Unicode.isAlpha`.
+letter :: forall m. Monad m => ParserT String m Char
+letter = satisfyCP isAlpha <?> "letter"
+
+-- | Parse an alphabetical or numerical character.
+-- | Matches any char that satisfies `Data.CodePoint.Unicode.isAlphaNum`.
+alphaNum :: forall m. Monad m => ParserT String m Char
+alphaNum = satisfyCP isAlphaNum <?> "letter or digit"
+
+-- | Parser based on the __Data.Number.fromString__ function.
+-- |
+-- | This should be the inverse of `show :: String -> Number`.
+-- |
+-- | Examples of strings which can be parsed by this parser:
+-- | * `"3"`
+-- | * `"3.0"`
+-- | * `"0.3"`
+-- | * `"-0.3"`
+-- | * `"+0.3"`
+-- | * `"-3e-1"`
+-- | * `"-3.0E-1.0"`
+-- | * `"NaN"`
+-- | * `"-Infinity"`
+number :: forall m. Monad m => ParserT String m Number
+-- TODO because the JavaScript parseFloat function will successfully parse
+-- a Number up until it doesn't understand something and then return
+-- the partially parsed Number, this parser will sometimes consume more
+-- String that it actually parses. Example "1..3" will parse as 1.0.
+-- So this needs improvement.
+number =
+  choice
+    [ Parser.String.string "Infinity" *> pure infinity
+    , Parser.String.string "+Infinity" *> pure infinity
+    , Parser.String.string "-Infinity" *> pure (negate infinity)
+    , Parser.String.string "NaN" *> pure nan
+    , do
+        Tuple section _ <- Parser.String.match do
+          _ <- Parser.String.oneOf [ '+', '-', '.', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' ]
+          skipMany $ Parser.String.oneOf [ 'e', 'E', '+', '-', '.', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' ]
+        -- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseFloat
+        case Data.Number.fromString section of
+          Nothing -> fail $ "Could not parse Number " <> section
+          Just x -> pure x
+    ]
+
+-- | Parser based on the __Data.Int.fromString__ function.
+-- |
+-- | This should be the inverse of `show :: String -> Int`.
+-- |
+-- | Examples of strings which can be parsed by this parser:
+-- | * `"3"`
+-- | * `"-3"`
+-- | * `"+300"`
+intDecimal :: forall m. Monad m => ParserT String m Int
+intDecimal = do
+  Tuple section _ <- Parser.String.match do
+    _ <- Parser.String.oneOf [ '+', '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' ]
+    skipMany $ Parser.String.oneOf [ '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' ]
+  case Data.Int.fromString section of
+    Nothing -> fail $ "Could not parse Int " <> section
+    Just x -> pure x
+
+-- | Helper function
+satisfyCP :: forall m. Monad m => (CodePoint -> Boolean) -> ParserT String m Char
+satisfyCP p = Parser.String.satisfy (p <<< codePointFromChar)


### PR DESCRIPTION
**Description of the change**

New module __Text.Parsing.Parser.String.Basic__

New functions
- `Parser.String.Basic.number`
- `Parser.String.Basic.intDecimal`

Moved the `Parser.Token` parsers `digit`, `hexDigit`, `octDigit`, `upper`, `space`, `letter`, `alphaNum` into the new module `Parser.String.Basic`.

Resolves the issues #73 #115 . Actually it doesn't resolve them directly because we still have the `float` token parser which was failing to parse correctly. We're keeping the `float` token parser which is documented to conform to “the grammar rules of the Haskell report,” but who knows if that's really true or not. Instead we've added a new `number` parser for parsing a `Number`, which I think is what most people want anyway.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
