### PR TITLE
Add `lower` parser to Text.Parsing.Parser.String.Basic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ New features:
 
 Bugfixes:
 
-Other improvements:
+Other improvements: Add `lower` parser to Text.Parsing.Parser.String.Basic.
 
 ## [v8.2.0](https://github.com/purescript-contrib/purescript-parsing/releases/tag/v8.2.0) - 2022-01-26
 

--- a/spago.dhall
+++ b/spago.dhall
@@ -18,6 +18,7 @@
   , "tailrec"
   , "transformers"
   , "tuples"
+  , "unfoldable"
   , "unicode"
   , "unsafe-coerce"
   ]

--- a/src/Text/Parsing/Parser/String/Basic.purs
+++ b/src/Text/Parsing/Parser/String/Basic.purs
@@ -10,6 +10,7 @@ module Text.Parsing.Parser.String.Basic
   , octDigit
   , letter
   , space
+  , lower
   , upper
   , alphaNum
   , intDecimal
@@ -19,7 +20,7 @@ module Text.Parsing.Parser.String.Basic
 
 import Prelude
 
-import Data.CodePoint.Unicode (isAlpha, isAlphaNum, isDecDigit, isHexDigit, isOctDigit, isSpace, isUpper)
+import Data.CodePoint.Unicode (isAlpha, isAlphaNum, isDecDigit, isHexDigit, isLower, isOctDigit, isSpace, isUpper)
 import Data.Int as Data.Int
 import Data.Maybe (Maybe(..))
 import Data.Number (infinity, nan)
@@ -43,6 +44,10 @@ hexDigit = satisfyCP isHexDigit <?> "hex digit"
 -- | Parse an octal digit.  Matches any char that satisfies `Data.CodePoint.Unicode.isOctDigit`.
 octDigit :: forall m. Monad m => ParserT String m Char
 octDigit = satisfyCP isOctDigit <?> "oct digit"
+
+-- | Parse a lowercase letter.  Matches any char that satisfies `Data.CodePoint.Unicode.isLower`.
+lower :: forall m. Monad m => ParserT String m Char
+lower = satisfyCP isLower <?> "lowercase letter"
 
 -- | Parse an uppercase letter.  Matches any char that satisfies `Data.CodePoint.Unicode.isUpper`.
 upper :: forall m. Monad m => ParserT String m Char


### PR DESCRIPTION
**Add `lower` parser to Text.Parsing.Parser.String.Basic.**

See also https://github.com/purescript-contrib/purescript-parsing/issues/151

Would also like to export helper function `satisfyCP` if it makes sense to you.

I didn't add tests for this change.
I had to change `spago.dhall` to make a build.

My purs version is: 0.14.5
spago: 0.20.7