### PR TITLE
Way to paste benchmark comparisons into Github

### DIFF
--- a/bench/tabletranspose.xslt
+++ b/bench/tabletranspose.xslt
@@ -1,0 +1,25 @@
+<!--
+
+https://stackoverflow.com/questions/4410084/transpose-swap-x-y-axes-in-html-table
+
+-->
+
+
+<xsl:stylesheet version="1.0"
+ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+ <xsl:output omit-xml-declaration="yes"/>
+ <xsl:template match="table">
+   <table>
+     <xsl:for-each select="tr[1]/td">
+      <xsl:variable name="vRowPos" select="position()"/>
+      <tr>
+       <xsl:for-each select="/table/tr">
+        <xsl:variable name="vColPos" select="position()"/>
+        <xsl:copy-of select="/table/tr[$vColPos]/td[$vRowPos]"/>
+       </xsl:for-each>
+      </tr>
+     </xsl:for-each>
+   </table>
+ </xsl:template>
+</xsl:stylesheet>
+

--- a/spago-dev.dhall
+++ b/spago-dev.dhall
@@ -14,6 +14,7 @@ in conf //
   , "console"
   , "enums"
   , "effect"
+  , "free"
   , "psci-support"
   , "minibench"
   , "exceptions"


### PR DESCRIPTION
The benchmarks provide a way to produce before-and-after tables which can be pasted as Github-flavored-Markdown.

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation in the README and/or documentation directory

