### PR TITLE
Add index field to Position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Breaking changes:
 - Rename module prefix from `Text.Parsing.Parser` to `Parsing` (#169 by @jamesdbrock)
 - Replace the `regex` parser. (#170 by @jamesdbrock)
 - Reorganize Combinators for #154 (#182 by @jamesdbrock)
+- Add the `index` field to `Position`. (#171 by @jamesdbrock)
 
 New features:
 

--- a/src/Parsing/Pos.purs
+++ b/src/Parsing/Pos.purs
@@ -3,25 +3,30 @@ module Parsing.Pos where
 import Prelude
 
 import Data.Generic.Rep (class Generic)
+import Data.Show.Generic (genericShow)
 
 -- | `Position` represents the position of the parser in the input.
 -- |
--- | - `line` is the current line in the input
--- | - `column` is the column of the next character in the current line that will be parsed
+-- | - `index` is the position since the start of the input. Starts at 0.
+-- | - `line` is the current line in the input. Starts at 1.
+-- | - `column` is the column of the next character in the current line that
+-- |   will be parsed. Starts at 1.
 newtype Position = Position
-  { line :: Int
+  { index :: Int
+  , line :: Int
   , column :: Int
   }
 
-derive instance genericPosition :: Generic Position _
+derive instance Generic Position _
+instance Show Position where
+  show x = genericShow x
 
-instance showPosition :: Show Position where
-  show (Position { line: line, column: column }) =
-    "(Position { line: " <> show line <> ", column: " <> show column <> " })"
+instance Eq Position where
+  eq (Position l) (Position r) = l.index == r.index
 
-derive instance eqPosition :: Eq Position
-derive instance ordPosition :: Ord Position
+instance Ord Position where
+  compare (Position l) (Position r) = compare l.index r.index
 
 -- | The `Position` before any input has been parsed.
 initialPos :: Position
-initialPos = Position { line: 1, column: 1 }
+initialPos = Position { index: 0, line: 1, column: 1 }


### PR DESCRIPTION
Add `index` field to `Position`

Regarding #162 #94 #172

I want to get rid of the `column` and `line` tracking in the `Parser`, and make that tracking an optional feature. This is a step towards that.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
