### PR TITLE
Combinators CPS reorganization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Breaking changes:
   without causing issues with `<$>`.
 - Rename module prefix from `Text.Parsing.Parser` to `Parsing` (#169 by @jamesdbrock)
 - Replace the `regex` parser. (#170 by @jamesdbrock)
+- Reorganize Combinators for #154 (#182 by @jamesdbrock)
 
 New features:
 

--- a/bench/Json/Parsing.purs
+++ b/bench/Json/Parsing.purs
@@ -10,8 +10,6 @@ import Data.Maybe (Maybe(..))
 import Data.Number as Number
 import Data.String.Regex.Flags (noFlags)
 import Data.Tuple (Tuple(..))
-import Effect.Exception (throw)
-import Effect.Unsafe (unsafePerformEffect)
 import Parsing (ParserT, fail)
 import Parsing.Combinators (between, choice, sepBy, try)
 import Parsing.String (regex, skipSpaces, string)

--- a/spago-dev.dhall
+++ b/spago-dev.dhall
@@ -14,7 +14,6 @@ in conf //
   , "console"
   , "enums"
   , "effect"
-  , "free"
   , "psci-support"
   , "minibench"
   , "exceptions"


### PR DESCRIPTION
Reorganize the Combinators to make sense with the CPS internals. These decisions were informed by benchmarking, see #177

* Export `many = List.manyRec`
* Delete `sepBy`, replace with `sepByRec`
* Delete `skipMany`, replace with `skipManyRec`
* Delete `chainl`, replace with `chainlRec`
* Delete `chainr`, replace with `chainrRec` (add `defer` https://github.com/purescript-contrib/purescript-parsing/issues/177#issuecomment-1090303356)
* Delete `manyTill`, replace with `manyTillRec`.

Resolves #177 

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
