### PR TITLE
Move parsers from `Parsing.String` to `Parsing.String.Basic`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,14 @@ Breaking changes:
 - Replace the `regex` parser. (#170 by @jamesdbrock)
 - Reorganize Combinators for #154 (#182 by @jamesdbrock)
 - Add the `index` field to `Position`. (#171 by @jamesdbrock)
+- Move the parsers
+  * `whiteSpace`
+  * `skipSpaces`
+  * `oneOf`
+  * `oneOfCodePoints`
+  * `noneOf`
+  * `noneOfCodePoints`
+  from `Parsing.String` to `Parsing.String.Basic`. (#183 by @jamesdbrock)
 
 New features:
 

--- a/bench/Json/Parsing.purs
+++ b/bench/Json/Parsing.purs
@@ -12,7 +12,8 @@ import Data.String.Regex.Flags (noFlags)
 import Data.Tuple (Tuple(..))
 import Parsing (ParserT, fail)
 import Parsing.Combinators (between, choice, sepBy, try)
-import Parsing.String (regex, skipSpaces, string)
+import Parsing.String (regex, string)
+import Parsing.String.Basic (skipSpaces)
 import Partial.Unsafe (unsafeCrashWith)
 
 json :: forall m. Monad m => ParserT String m Json

--- a/src/Parsing/Indent.purs
+++ b/src/Parsing/Indent.purs
@@ -69,7 +69,8 @@ import Data.Maybe (Maybe(..))
 import Parsing (ParserT, fail, position)
 import Parsing.Combinators (option, optionMaybe)
 import Parsing.Pos (Position(..), initialPos)
-import Parsing.String (oneOf, string)
+import Parsing.String (string)
+import Parsing.String.Basic (oneOf)
 
 -- | Indentation sensitive parser type. Usually @ m @ will
 -- | be @ Identity @ as with any @ ParserT @

--- a/src/Parsing/Language.purs
+++ b/src/Parsing/Language.purs
@@ -13,8 +13,8 @@ import Prelude
 
 import Control.Alt ((<|>))
 import Parsing (ParserT)
-import Parsing.String (char, oneOf)
-import Parsing.String.Basic (alphaNum, letter)
+import Parsing.String (char)
+import Parsing.String.Basic (alphaNum, letter, oneOf)
 import Parsing.Token (GenLanguageDef(..), LanguageDef, TokenParser, makeTokenParser, unGenLanguageDef)
 
 -----------------------------------------------------------

--- a/src/Parsing/Token.purs
+++ b/src/Parsing/Token.purs
@@ -46,9 +46,9 @@ import Data.Tuple (Tuple(..))
 import Parsing (ParseState(..), ParserT, consume, fail)
 import Parsing.Combinators (between, choice, notFollowedBy, option, sepBy, sepBy1, skipMany, skipMany1, try, tryRethrow, (<?>), (<??>))
 import Parsing.Pos (Position)
-import Parsing.String (char, noneOf, oneOf, satisfy, satisfyCodePoint, string)
+import Parsing.String (char, satisfy, satisfyCodePoint, string)
+import Parsing.String.Basic (alphaNum, digit, hexDigit, letter, noneOf, octDigit, oneOf, space, upper)
 import Parsing.String.Basic as Basic
-import Parsing.String.Basic (digit, hexDigit, octDigit, upper, space, letter, alphaNum)
 
 -- | A parser which returns the first token in the stream.
 token :: forall m a. (a -> Position) -> ParserT (List a) m a

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -30,8 +30,8 @@ import Parsing.Combinators (between, chainl, chainl1, chainr, chainr1, choice, e
 import Parsing.Expr (Assoc(..), Operator(..), buildExprParser)
 import Parsing.Language (haskellDef, haskellStyle, javaStyle)
 import Parsing.Pos (Position(..), initialPos)
-import Parsing.String (anyChar, anyCodePoint, char, eof, regex, noneOfCodePoints, oneOfCodePoints, rest, satisfy, string, takeN, whiteSpace)
-import Parsing.String.Basic (intDecimal, number, letter)
+import Parsing.String (anyChar, anyCodePoint, char, eof, regex, rest, satisfy, string, takeN)
+import Parsing.String.Basic (intDecimal, number, letter, noneOfCodePoints, oneOfCodePoints, whiteSpace)
 import Parsing.Token (TokenParser, makeTokenParser, match, token, when)
 import Parsing.Token as Parser.Token
 import Partial.Unsafe (unsafePartial)


### PR DESCRIPTION
Move the parsers

* `whiteSpace`
* `skipSpaces`
* `oneOf`
* `oneOfCodePoints`
* `noneOf`
* `noneOfCodePoints`

from `Parsing.String` to `Parsing.String.Basic`.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
