### PR TITLE
anyTill String combinator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ Breaking changes:
 
 New features:
 
+- Add the `anyTill` primitive `String` combinator. (#186 by @jamesdbrock)
+
 Bugfixes:
 
 Other improvements:

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,4 +1,5 @@
 let upstream =
       https://raw.githubusercontent.com/purescript/package-sets/prepare-0.15/src/packages.dhall
+        sha256:b1c6d06132b7cbf1e93b1e5343044fba1604b50bfbe02d8f80a3002e71569c59
 
 in  upstream

--- a/src/Parsing/Combinators.purs
+++ b/src/Parsing/Combinators.purs
@@ -173,16 +173,16 @@ try (ParserT k1) = ParserT
 
 -- | If the parser fails then backtrack the input stream to the unconsumed state.
 -- |
--- | Like `try`, but will relocate the error to the `try` point.
+-- | Like `try`, but will reposition the error to the `try` point.
 -- |
 -- | ```
 -- | >>> runParser "ac" (try (char 'a' *> char 'b'))
--- | Left (ParseError "Expected 'b'" (Position { line: 1, column: 2 }))
+-- | Left (ParseError "Expected 'b'" (Position { index: 1, line: 1, column: 2 }))
 -- | ```
 -- |
 -- | ```
 -- | >>> runParser "ac" (tryRethrow (char 'a' *> char 'b'))
--- | Left (ParseError "Expected 'b'" (Position { line: 1, column: 1 }))
+-- | Left (ParseError "Expected 'b'" (Position { index: 0, line: 1, column: 1 }))
 -- | ```
 tryRethrow :: forall m s a. ParserT s m a -> ParserT s m a
 tryRethrow (ParserT k1) = ParserT

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -30,7 +30,7 @@ import Parsing.Combinators (between, chainl, chainl1, chainr, chainr1, choice, e
 import Parsing.Expr (Assoc(..), Operator(..), buildExprParser)
 import Parsing.Language (haskellDef, haskellStyle, javaStyle)
 import Parsing.Pos (Position(..), initialPos)
-import Parsing.String (anyChar, anyCodePoint, char, eof, regex, rest, satisfy, string, takeN)
+import Parsing.String (anyChar, anyCodePoint, anyTill, char, eof, regex, rest, satisfy, string, takeN)
 import Parsing.String.Basic (intDecimal, number, letter, noneOfCodePoints, oneOfCodePoints, whiteSpace)
 import Parsing.Token (TokenParser, makeTokenParser, match, token, when)
 import Parsing.Token as Parser.Token
@@ -827,3 +827,10 @@ main = do
       let messageExpected = "context1 context2 Expected \"b\""
       assert' ("expected message: " <> messageExpected <> ", message: " <> message) (message == messageExpected)
       logShow messageExpected
+
+  log "\nTESTS anyTill\n"
+  parseTest "𝅘𝅥𝅮𝅘𝅥𝅘𝅥𝅘𝅥𝅘𝅥" (Tuple "" "𝅘𝅥𝅮") $ anyTill (string "𝅘𝅥𝅮")
+  parseTest "𝅘𝅥𝅘𝅥𝅘𝅥𝅮𝅘𝅥𝅘𝅥" (Tuple "𝅘𝅥𝅘𝅥" "𝅘𝅥𝅮") $ anyTill (string "𝅘𝅥𝅮")
+  parseTest "𝅘𝅥𝅘𝅥𝅘𝅥𝅘𝅥𝅘𝅥𝅮" (Tuple "𝅘𝅥𝅘𝅥𝅘𝅥𝅘𝅥" "𝅘𝅥𝅮") $ anyTill (string "𝅘𝅥𝅮") <* eof
+  parseErrorTestPosition (anyTill (string "𝅘𝅥𝅮")) "𝅘𝅥𝅘𝅥𝅘𝅥𝅘𝅥" (Position { index: 4, line: 1, column: 5 })
+


### PR DESCRIPTION
This primitive combinator enables features like string split, search,
and search-and-replace.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
