### PR TITLE
Change MonadState instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@ Breaking changes:
   * `noneOf`
   * `noneOfCodePoints`
   from `Parsing.String` to `Parsing.String.Basic`. (#183 by @jamesdbrock)
+- Change MonadState instance (#187 by jamesdbrock)
+
+  Users who stack a `ParserT` on a `StateT` base monad will call the `MonadState` members directly like `get` instead of needing to do `lift <<< get`.
+
+  To get the `ParserT` internal state, call `getParserT` instead of `get`.
 
 New features:
 

--- a/src/Parsing/String.purs
+++ b/src/Parsing/String.purs
@@ -52,7 +52,6 @@ module Parsing.String
 import Prelude hiding (between)
 
 import Control.Monad.Rec.Class (Step(..), tailRecM)
-import Control.Monad.State (get)
 import Data.Array.NonEmpty as NonEmptyArray
 import Data.Either (Either(..))
 import Data.Enum (fromEnum, toEnum)
@@ -64,7 +63,7 @@ import Data.String.CodeUnits as SCU
 import Data.String.Regex as Regex
 import Data.String.Regex.Flags (RegexFlags)
 import Data.Tuple (Tuple(..))
-import Parsing (ParseError(..), ParseState(..), ParserT(..), Position(..))
+import Parsing (ParseError(..), ParseState(..), ParserT(..), Position(..), getParserT)
 import Parsing.Combinators (alt, try, (<?>))
 import Partial.Unsafe (unsafePartial)
 
@@ -195,9 +194,9 @@ updatePosSingle (Position { index, line, column }) cp after = case fromEnum cp o
 -- | ```
 match :: forall m a. ParserT String m a -> ParserT String m (Tuple String a)
 match p = do
-  ParseState input1 _ _ <- get
+  ParseState input1 _ _ <- getParserT
   x <- p
-  ParseState input2 _ _ <- get
+  ParseState input2 _ _ <- getParserT
   -- We use the `SCU.length`, which is in units of “code units”
   -- instead of `Data.String.length`. which is in units of “code points”.
   -- This is more efficient, and it will be correct as long as we can assume
@@ -300,13 +299,13 @@ anyTill
   => ParserT String m a
   -> ParserT String m (Tuple String a)
 anyTill p = do
-  ParseState input1 _ _ <- get
+  ParseState input1 _ _ <- getParserT
   Tuple input2 t <- tailRecM go unit
   pure $ Tuple (SCU.take (SCU.length input1 - SCU.length input2) input1) t
   where
   go unit = alt
     ( do
-        ParseState input2 _ _ <- get
+        ParseState input2 _ _ <- getParserT
         t <- try p
         pure $ Done $ Tuple input2 t
     )


### PR DESCRIPTION
`state` refers to base monad instead of `ParseState`

Resolves #56 

With this PR, users who stack a `ParserT` on a `StateT` base monad will call the `MonadState` members directly like `get` instead of needing to do `lift <<< get`.

To get the `ParserT` internal state, call `getParserT` instead of `get`.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
