### PR TITLE
Improve String.Basic.number, String.Basic.intDecimal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,10 @@ New features:
 
 Bugfixes:
 
+- Improve correctness and speed of `number` and `intDecimal`. (#189 by @jamesdbrock)
+
 Other improvements:
+
 - Drop `math` dependency; update imports (#167 by @JordanMartinez)
 
 ## [v8.4.0](https://github.com/purescript-contrib/purescript-parsing/releases/tag/v8.4.0) - 2022-03-15


### PR DESCRIPTION
Improve `String.Basic.number`, `String.Basic.intDecimal` parsers

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
