### PR TITLE
advance, manyIndex combinators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ New features:
 - Add the `anyTill` primitive `String` combinator. (#186 by @jamesdbrock)
 - Add the `Parsing.String.Replace` module, copied from
   https://github.com/jamesdbrock/purescript-parsing-replace (#188 by @jamesdbrock)
+- Add the `advance` and `manyIndex` combinators. (#193 by @jamesdbrock)
 
 Bugfixes:
 

--- a/src/Parsing.purs
+++ b/src/Parsing.purs
@@ -404,10 +404,11 @@ region context p = catchError p $ \err -> throwError $ context err
 
 -- | `Position` represents the position of the parser in the input stream.
 -- |
--- | - `index` is the position since the start of the input. Starts at 0.
--- | - `line` is the current line in the input. Starts at 1.
+-- | - `index` is the position offset since the start of the input. Starts
+-- |   at *0*.
+-- | - `line` is the current line in the input. Starts at *1*.
 -- | - `column` is the column of the next character in the current line that
--- |   will be parsed. Starts at 1.
+-- |   will be parsed. Starts at *1*.
 newtype Position = Position
   { index :: Int
   , line :: Int


### PR DESCRIPTION
Add the `advance`, `manyIndex` combinators.

Resolves #57 #120

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
