### PR TITLE
replaceT instead of streamEditT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@ New features:
 - Add the `anyTill` primitive `String` combinator. (#186 by @jamesdbrock)
 - Add the `Parsing.String.Replace` module, copied from
   https://github.com/jamesdbrock/purescript-parsing-replace (#188 by @jamesdbrock)
+  `streamEditT` can be written in terms of `replaceT`.
+
+  `streamEditT input sep editor = replaceT input (sep >>= editor >>> lift)`
+
+  (#188 by @jamesdbrock, #194 by @jamesdbrock)
 - Add the `advance` and `manyIndex` combinators. (#193 by @jamesdbrock)
 
 Bugfixes:


### PR DESCRIPTION
`replaceT` is a better API and also more elemental than `streamEditT`, because `streamEditT` can be written in terms of
`replaceT`.

```purescript
streamEditT input sep editor = replaceT input (sep >>= editor >>> lift)
```

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
