### PR TITLE
consumeWith doesn't consume if position does not advance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ Notable changes to this project are documented in this file. The format is based
 
 ## [Unreleased]
 
+Bugfixes:
+
+- consumeWith doesn't consume if position does not advance (#201 by @jamesdbrock)
+
+  This will effect parsers:
+
+  * rest
+  * string
+  * takeN
+  * regex
+  * whiteSpace
+  * skipSpaces
+
+
 ## [v9.1.0](https://github.com/purescript-contrib/purescript-parsing/releases/tag/v9.1.0) - 2022-06-12
 
 Breaking changes:

--- a/src/Parsing/String.purs
+++ b/src/Parsing/String.purs
@@ -283,6 +283,8 @@ regex pattern flags =
 -- |
 -- | * `value` is the value to return.
 -- | * `consumed` is the input `String` that was consumed. It is used to update the parser position.
+-- |   If the `consumed` `String` is non-empty then the `consumed` flag will
+-- |   be set to true. (Confusing terminology.)
 -- | * `remainder` is the new remaining input `String`.
 -- |
 -- | This function is used internally to construct primitive `String` parsers.
@@ -296,7 +298,7 @@ consumeWith f = ParserT
         Left err ->
           runFn2 throw state1 (ParseError err pos)
         Right { value, consumed, remainder } ->
-          runFn2 done (ParseState remainder (updatePosString pos consumed remainder) true) value
+          runFn2 done (ParseState remainder (updatePosString pos consumed remainder) (not (String.null consumed))) value
   )
 
 -- | Combinator which finds the first position in the input `String` where the

--- a/src/Parsing/String/Basic.purs
+++ b/src/Parsing/String/Basic.purs
@@ -148,11 +148,17 @@ satisfyCP :: forall m. (CodePoint -> Boolean) -> ParserT String m Char
 satisfyCP p = satisfy (p <<< codePointFromChar)
 
 -- | Match zero or more whitespace characters satisfying
--- | `Data.CodePoint.Unicode.isSpace`. Always succeeds.
+-- | `Data.CodePoint.Unicode.isSpace`.
+-- |
+-- | Always succeeds. Will consume only when matched whitespace string
+-- | is non-empty.
 whiteSpace :: forall m. ParserT String m String
 whiteSpace = fst <$> match skipSpaces
 
--- | Skip whitespace characters and throw them away. Always succeeds.
+-- | Skip whitespace characters satisfying `Data.CodePoint.Unicode.isSpace`
+-- | and throw them away.
+-- |
+-- | Always succeeds. Will only consume when some characters are skipped.
 skipSpaces :: forall m. ParserT String m Unit
 skipSpaces = consumeWith \input -> do
   let consumed = takeWhile isSpace input


### PR DESCRIPTION
issue #200

This will effect parsers:

* rest
* string
* takeN
* regex
* whiteSpace
* skipSpaces

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
