### PR TITLE
A decimal exponent is not required for a number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Bugfixes:
   * whiteSpace
   * skipSpaces
 
+- `number` should parse scientific notation when exponent does not contain a decimal (#204 by @MaybeJustJames)
+
 
 ## [v9.1.0](https://github.com/purescript-contrib/purescript-parsing/releases/tag/v9.1.0) - 2022-06-12
 

--- a/src/Parsing/String/Basic.purs
+++ b/src/Parsing/String/Basic.purs
@@ -120,7 +120,7 @@ number =
 numberRegex :: forall m. ParserT String m String
 numberRegex = either unsafeCrashWith identity $ regex pattern mempty
   where
-  pattern = "[+-]?[0-9]*(\\.[0-9]*)?([eE][+-]?[0-9]*(\\.[0-9]*))?"
+  pattern = "[+-]?[0-9]*(\\.[0-9]*)?([eE][+-]?[0-9]*(\\.[0-9]*)?)?"
 
 -- | Parser based on the __Data.Int.fromString__ function.
 -- |

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -726,6 +726,11 @@ main = do
     , expected: Right (-0.3)
     }
 
+  assertEqual' "number xEy"
+    { actual: runParser "2e1" number
+    , expected: Right 20.0
+    }
+
   -- test from issue #73
   assertEqual' "number 2"
     { actual: runParser "0.7531531167929774" number


### PR DESCRIPTION
This ensures that a decimal exponent is optional in the `Parsing.String.Basic.number` parser. Fixes #203.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
