### PR TITLE
minibench v4.0.1

### DIFF
--- a/packages.dhall
+++ b/packages.dhall
@@ -3,3 +3,4 @@ let upstream =
         sha256:169bd823a71ae033eaf4f77776e184f12c656163feae14e7f649a48932ca6ac0
 
 in  upstream
+  with minibench.version = "77329a816a4be933cd3c51cc8517608d5affb450"

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,5 +1,5 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.15.0-20220525/packages.dhall
-        sha256:5facfdf9c35801a0e6a41b08b4293f947743007a9224a2a3d7694d87a44a7f28
+      https://github.com/purescript/package-sets/releases/download/psc-0.15.4-20220921/packages.dhall
+        sha256:169bd823a71ae033eaf4f77776e184f12c656163feae14e7f649a48932ca6ac0
 
 in  upstream


### PR DESCRIPTION
Upgrade package-sets and use minibench 4.0.1