### PR TITLE
New String function: parseErrorHuman

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Breaking changes:
 New features:
 
 - add `MonadAsk` and `MonadReader` instances (#208 by @bentongxyz)
+- Add `Parsing.String.parseErrorHuman` (#209 by @jamesdbrock)
 
 Other improvements:
 

--- a/src/Parsing.purs
+++ b/src/Parsing.purs
@@ -51,9 +51,11 @@ import Data.Tuple (Tuple(..), fst)
 -- | the position in the input stream at which the error occurred.
 data ParseError = ParseError String Position
 
+-- | Get the `Message` from a `ParseError`
 parseErrorMessage :: ParseError -> String
 parseErrorMessage (ParseError msg _) = msg
 
+-- | Get the `Position` from a `ParseError`.
 parseErrorPosition :: ParseError -> Position
 parseErrorPosition (ParseError _ pos) = pos
 


### PR DESCRIPTION
New String function: `parseErrorHuman`

> Returns three `String`s which, when printed line-by-line, will show a nice human-readable parsing error message.

```haskell
    let input = "12345six789"
    case runParser input (replicateA 9 String.Basic.digit) of
      Left err -> log $ String.joinWith "\n" $ parseErrorHuman input 20 err
```

```
Expected digit at position index:5 (line:1, column:6)
     ▼
12345six789
```

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [ ] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
