### PR TITLE
Makes "float" parser of GenTokenParser parse negative numbers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Notable changes to this project are documented in this file. The format is based
 ## [Unreleased]
 
 Bugfixes:
+- `float` parser of `GenTokenParser` does not parse negative numbers (by @mstream)
 
 Breaking changes:
 

--- a/src/Parsing/Token.purs
+++ b/src/Parsing/Token.purs
@@ -34,7 +34,7 @@ import Data.Int (toNumber)
 import Data.List (List(..))
 import Data.List as List
 import Data.List.NonEmpty (NonEmptyList)
-import Data.Maybe (Maybe(..), maybe)
+import Data.Maybe (Maybe(..), fromMaybe, maybe)
 import Data.Number (pow)
 import Data.String (null, toLower)
 import Data.String.CodePoints (codePointFromChar)
@@ -43,7 +43,7 @@ import Data.String.CodeUnits as SCU
 import Data.String.Unicode as Unicode
 import Data.Tuple (Tuple(..))
 import Parsing (ParseState(..), ParserT, Position, consume, fail, getParserT, stateParserT)
-import Parsing.Combinators (between, choice, notFollowedBy, option, sepBy, sepBy1, skipMany, skipMany1, try, tryRethrow, (<?>), (<??>))
+import Parsing.Combinators (between, choice, notFollowedBy, option, optionMaybe, sepBy, sepBy1, skipMany, skipMany1, try, tryRethrow, (<?>), (<??>))
 import Parsing.String (char, satisfy, satisfyCodePoint, string)
 import Parsing.String.Basic (alphaNum, digit, hexDigit, letter, noneOf, octDigit, oneOf, space, upper)
 import Parsing.String.Basic as Basic
@@ -608,7 +608,10 @@ makeTokenParser (LanguageDef languageDef) =
 
   -- floats
   floating :: ParserT String m Number
-  floating = decimal >>= fractExponent
+  floating = do
+    f <- fromMaybe identity <$> optionMaybe sign
+    x <- decimal >>= fractExponent
+    pure $ f x
 
   natFloat :: ParserT String m (Either Int Number)
   natFloat = char '0' *> zeroNumFloat

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -392,6 +392,9 @@ tokenParserFloatTest = do
   -- parse float
   parseTest "100.5" 100.5 testTokenParser.float
 
+  -- parse a negative float
+  parseTest "-100.5" (-100.5) testTokenParser.float
+
   -- parse float with exponent
   parseTest "100e1" 1000.0 testTokenParser.float
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -392,6 +392,9 @@ tokenParserFloatTest = do
   -- parse float
   parseTest "100.5" 100.5 testTokenParser.float
 
+  -- parse float prefixed with a plus sign
+  parseTest "+100.5" 100.5 testTokenParser.float
+
   -- parse a negative float
   parseTest "-100.5" (-100.5) testTokenParser.float
 
@@ -400,6 +403,9 @@ tokenParserFloatTest = do
 
   -- parse float with exponent
   parseTest "100.5e1" 1005.0 testTokenParser.float
+
+  -- parse a negative float with exponent
+  parseTest "-100.5e1" (-1005.0) testTokenParser.float
 
   -- fail on nonfloat
   parseErrorTestPosition testTokenParser.float "100.e1" $ mkPos 5


### PR DESCRIPTION
Resolves #115

Makes the `float` parser consider a sign, if present, in front of a floating number.