### PR TITLE
purs-tidy format-in-place src test bench

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,3 @@ jobs:
 
       - name: Check formatting
         run: purs-tidy check src test bench
-
-      - name: Verify Bower & Pulp
-        run: |
-          npm install bower pulp@16.0.0-0
-          npx bower install
-          npx pulp build -- --censor-lib --strict

--- a/test/Test/IndentationTests.purs
+++ b/test/Test/IndentationTests.purs
@@ -59,28 +59,28 @@ testIndentationParser :: TestM
 testIndentationParser = do
   parseTest
     ( joinWith "\n"
-      [ "k        \n"
-      , "  a1     \n"
-      , "  a2     \n"
-      , "   b1    \n"
-      , "  a3     \n"
-      , "   haha  \n"
-      , "   it    \n"
-      , "   works \n"
-      , "    "
-      ]
+        [ "k        \n"
+        , "  a1     \n"
+        , "  a2     \n"
+        , "   b1    \n"
+        , "  a3     \n"
+        , "   haha  \n"
+        , "   it    \n"
+        , "   works \n"
+        , "    "
+        ]
     )
     ( Taxonomy "k"
-      [ Taxonomy "a1" []
-      , Taxonomy "a2"
-          [ Taxonomy "b1" []
-          ]
-      , Taxonomy "a3"
-          [ Taxonomy "haha"  []
-          , Taxonomy "it"    []
-          , Taxonomy "works" []
-          ]
-      ]
+        [ Taxonomy "a1" []
+        , Taxonomy "a2"
+            [ Taxonomy "b1" []
+            ]
+        , Taxonomy "a3"
+            [ Taxonomy "haha" []
+            , Taxonomy "it" []
+            , Taxonomy "works" []
+            ]
+        ]
     )
     (pTaxonomy <* eof)
 
@@ -98,25 +98,27 @@ testIndentationParser = do
         eof
         pure { x, y, z }
 
-  parseErrorTestPositionAndMessage (do
-    x <- intDecimal
-    void $ string "\n  "
-    indented *> withPos do
-      checkIndent -- This should pass.
-      y <- intDecimal
-      void $ string "\n"
-      indented *> withPos do -- indented should fail
-        z <- intDecimal
-        eof
-        pure { x, y, z }
+  parseErrorTestPositionAndMessage
+    ( do
+        x <- intDecimal
+        void $ string "\n  "
+        indented *> withPos do
+          checkIndent -- This should pass.
+          y <- intDecimal
+          void $ string "\n"
+          indented *> withPos do -- indented should fail
+            z <- intDecimal
+            eof
+            pure { x, y, z }
     )
     "111\n  222\n333"
     """not indented"""
     (Position { column: 1, index: 10, line: 3 })
 
   -- Testing function 'indentParens'
-  parseTest "(1,2,3)" (fromFoldable ["1", "2", "3"]) $
-    indentParens $ sepBy (string "1" <|> string "2" <|> string "3") (char ',')
+  parseTest "(1,2,3)" (fromFoldable [ "1", "2", "3" ])
+    $ indentParens
+    $ sepBy (string "1" <|> string "2" <|> string "3") (char ',')
 
   -- doesnt work, dont understand idea of this method
   -- parseTest """(\n  1,\n  2,\n  3)""" (fromFoldable ["1", "2", "3"]) $

--- a/test/Test/Lib.purs
+++ b/test/Test/Lib.purs
@@ -27,7 +27,7 @@ mkParseTest runParser input expected p = case runParser input p of
   Right actual -> do
     assert' ("expected output: " <> show expected <> ", actual output: " <> show actual) (expected == actual)
     logShow actual
-  Left err -> assert' (joinWith "\n" $ ["error: " <> show err] <> parseErrorHuman__onlyString input 60 err) false
+  Left err -> assert' (joinWith "\n" $ [ "error: " <> show err ] <> parseErrorHuman__onlyString input 60 err) false
 
 mkParseErrorTestPosition :: forall s a m. Show a => (s -> ParserT s m a -> Either ParseError a) -> ParserT s m a -> s -> Position -> Effect Unit
 mkParseErrorTestPosition runParser p input expected = case runParser input p of


### PR DESCRIPTION
**Description of the change**

- `purs-tidy format-in-place src test bench`
- Remove CI step **Verify Bower & Pulp**.