### PR TITLE
consumeWith: propagate `consumed` flag when it was set

### DIFF
--- a/src/Parsing/String.purs
+++ b/src/Parsing/String.purs
@@ -282,12 +282,12 @@ consumeWith
    . (String -> Either String { value :: a, consumed :: String, remainder :: String })
   -> ParserT String m a
 consumeWith f = ParserT
-  ( mkFn5 \state1@(ParseState input pos _) _ _ throw done ->
+  ( mkFn5 \state1@(ParseState input pos oldConsumed) _ _ throw done ->
       case f input of
         Left err ->
           runFn2 throw state1 (ParseError err pos)
         Right { value, consumed, remainder } ->
-          runFn2 done (ParseState remainder (updatePosString pos consumed remainder) (not (String.null consumed))) value
+          runFn2 done (ParseState remainder (updatePosString pos consumed remainder) (oldConsumed || not (String.null consumed))) value
   )
 
 -- | Combinator which finds the first position in the input `String` where the


### PR DESCRIPTION
**Description of the change**

The Parsing design implies that if input was consumed, it must propagate further unless `try` is used to reset that.

Fixes: https://github.com/purescript-contrib/purescript-parsing/issues/236

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
