### PR TITLE
Fix consumed semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Notable changes to this project are documented in this file. The format is based
 
 Bugfixes:
 - `float` parser of `GenTokenParser` does not parse negative numbers (by @mstream)
+- Fixes `consumed` semantics which could cause unexpected backtracking instead of a failure (by @natefaubion)
 
 Breaking changes:
 

--- a/src/Parsing.purs
+++ b/src/Parsing.purs
@@ -80,6 +80,7 @@ derive instance ordParseError :: Ord ParseError
 -- | - If the left parser fails *without consuming any input*, then backtrack and try the right parser.
 -- | - If the left parser fails and consumes input, then fail immediately.
 data ParseState s = ParseState s Position Boolean
+
 -- ParseState constructor has three parameters,
 -- s: the remaining input
 -- Position: the current position

--- a/src/Parsing/String.purs
+++ b/src/Parsing/String.purs
@@ -282,12 +282,12 @@ consumeWith
    . (String -> Either String { value :: a, consumed :: String, remainder :: String })
   -> ParserT String m a
 consumeWith f = ParserT
-  ( mkFn5 \state1@(ParseState input pos oldConsumed) _ _ throw done ->
+  ( mkFn5 \state1@(ParseState input pos _) _ _ throw done ->
       case f input of
         Left err ->
           runFn2 throw state1 (ParseError err pos)
         Right { value, consumed, remainder } ->
-          runFn2 done (ParseState remainder (updatePosString pos consumed remainder) (oldConsumed || not (String.null consumed))) value
+          runFn2 done (ParseState remainder (updatePosString pos consumed remainder) (not (String.null consumed))) value
   )
 
 -- | Combinator which finds the first position in the input `String` where the


### PR DESCRIPTION
This effectively treats the consumed flag as a monoid appended on each sequential action (ie, Writer). This means it can always be a local decision so low-level combinators don't need to consult the previous state.

Fixes #235

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
